### PR TITLE
Use 'find' instead of 'children'

### DIFF
--- a/extensions/toc/deck.toc.js
+++ b/extensions/toc/deck.toc.js
@@ -124,9 +124,9 @@ This module provides a support for TOC to the deck.
             
             /* If there is a toc item, push it in the TOC */
             for(var level=1; level<6; level++) {
-                if( slide.children("h"+level).length > 0) {
+                if( slide.find("h"+level).length > 0) {
                     var tocTitle = "";
-                    var $tocElement = slide.children("h"+level+":first");
+                    var $tocElement = slide.find("h"+level+":first");
                     if( $tocElement.attr("title") != undefined && $tocElement.attr("title") != "") {
                         tocTitle = $tocElement.attr("title");
                     } else {


### PR DESCRIPTION
I've changed the code which searches for heading to use 'find' instead of 'children'. This is required if, for example, the scale extension is used, since it adds a div between the slide and its contents, breaking the algorithm.
