### PR TITLE
Add a plugin to animate HTML elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Currently Deck.ext.js provides the following extensions:
 - deck.asvg.js, provides a support for including and animating SVG images,
 - deck.clone.js, provides a support for cloning a deck presentation to another window,
 - deck.notes.js, provides a support for adding and viewing speaker notes.
+- deck.animator.js, provides a support for animating HTML elements.
 
 Currently Deck.ext.js provides the following themes:
 
@@ -99,6 +100,9 @@ To clone a deck presentation just press `c`.
 The `deck.notes.js` extensions allows users to toggle speaker notes display by pressing the `n` key.
 To add a note to a slide just add a simple div with a .notes class like below:
 
+
+### Example
+
         <section class="slide" id="title-slide">
             <h1>The Presentation Title</h1>
         </section>
@@ -125,3 +129,69 @@ To add a note to a slide just add a simple div with a .notes class like below:
         </section>
 
 This extension is better used together with the `deck.clone.js` extension.
+
+##deck.animator.js extension
+
+The `deck.animator.js` extension allows users animate HTML elements in their slides.
+There is at most an animator for each slide.
+
+The slide is linked to its animator thanks to the value of its custom attribute `data-dahu-animator`.
+The JSON description of an animation follows the following format: 
+
+        {
+          "id": A chain to identify the JSON object,
+          "target": A CSS selector for the slides in which the animation occurs,
+          "actions": [
+            {
+              "id": A chain to identify the action,
+              "type": either "move", "appear" or "disappear",
+              "target": The id of the HTML element to which the action applies,
+              "duration": The duration of the action in ms,
+              "trX": ("move" type only) the value in pixels of the abs translation,
+              "trY": ("move" type only) the value in pixels of the ord translation
+            },
+            ...
+          ]
+        }
+
+The following example makes the text disappear, then move and reappear as it moves:
+
+
+### Example
+
+        <section class="slide" id="containing_slide" data-dahu-animator="animDescription">
+            <div id="moving_text">
+                This text is animated
+            </div>
+            <script type="text/javascript">
+                var animDescription = {
+                    "id": "animator1",
+                    "target": "#containing_slide",
+                    "actions": [
+                        {
+                            "id": "action1",
+                            "type": "disappear",
+                            "target": "#moving_text",
+                            "trigger": "onChange",
+                            "duration": 1000
+                        },
+                        {  
+                            "id": "action2,
+                            "type": "move",
+                            "target": "#moving_text",
+                            "trigger": "afterPrevious",
+                            "trX": 150,
+                            "trY": 100,
+                            "duration": 2000
+                        },
+                        {
+                            "id": "action3",
+                            "type": "appear",
+                            "target": "#moving_text",
+                            "trigger": "withPrevious",
+                            "duration": 1000
+                        }
+                    ]
+                };
+            </script>
+        </section>

--- a/extensions/animator/animator.js
+++ b/extensions/animator/animator.js
@@ -28,13 +28,21 @@ function Animator(target, animations) {
 		*/
 		completedReverse: 'deck.animator.completedReverse',
 		
-                /*
-		This event fires whenever an animation is performed. The callback
+		/*
+		This event fires whenever a sequence of animations is performed. The callback
                 function is passed two parameters, target and index, equal to
                 the target on which the animation is performed and the index of
                 the animation i.e between 0 and animation.lenght.
 		*/
 		progress: 'deck.animator.progress',
+		
+		/*
+		This event fires whenever a sequence of reverse animations is performed. The callback
+                function is passed two parameters, target and index, equal to
+                the target on which the animation is performed and the index of
+                the animation i.e between 0 and animation.lenght.
+		*/
+		progressReverse: 'deck.animator.progressReverse',
                 
 		/*
 		This event fires at the beginning of deck.animator initialization.
@@ -44,7 +52,7 @@ function Animator(target, animations) {
 		/*
 		This event fires at the end of deck.animator initialization.
 		*/
-		initialize: 'deck.animator.init' 
+		initialize: 'deck.animator.init'
 	};
     
     if( $.isArray(animations) ) {
@@ -58,7 +66,7 @@ function Animator(target, animations) {
         Restart animator.
         */
     this.restart = function() {
-        init();
+        this.init();
 		this.next();
     }
 	
@@ -66,49 +74,92 @@ function Animator(target, animations) {
 		Start animator from the last state.
 		*/
 	this.startFromTheEnd = function() {
-		init();
+		this.init();
 		animations.forEach( function(a){
-			console.log("startFromEnd");
             a.play(target, false, true);
 			cursor++;
         });
 		$(document).trigger(events.completed, {'target':target});
 	}
 	
+	/*
+		Return true if animation has started playing.
+		*/
 	this.hasStarted = function() {
 		return cursor > 0;
 	}
+	
+	/*  
+        Return true if animation is complete.
+        */
+    this.isCompleted = function() {
+        return cursor == anims.length;
+    }
+	
+	this.isOnGoing = function() {
+		animations.forEach(function(a){
+			if(a.action.playing) return true;
+		});
+		return false;
+	}
+	
+	/*
+		Play a sequence of animation.
+		*/
+	this.play = function(animationSequence, isReversed, skip) {
+		if(animationSequence.length === 0) return;
+		var lastPlayed = 0;
+		animationSequence[0].play(target, isReversed, skip);
+		for(i = 1; i < animationSequence.length && (animationSequence[i].action.trigger === TriggerEnum.WITHPREVIOUS || isReversed); ++i) {
+			animationSequence[i].play(target, isReversed, skip);
+			lastPlayed = i;
+		}
+		if(animationSequence[lastPlayed].index === animations.length && !isReversed) {
+			$(document).trigger(events.completed, {'target':target});
+		}
+		if(animationSequence[lastPlayed].index === 0 && isReversed) {
+			$(document).trigger(events.completedReverse, {'target':target});
+		}
+	}
 
     /*  
-        Move to next animation.
+        Move to the next state (right before an afterPrevious-triggered action and, 
+		by extension by calling this.play, right before the next onClick-triggered action).
         */
     this.next = function() {
         if( cursor < anims.length ) {
+			// if a sequence of action is ongoing, prevent the next action from playing
+			if(animations[cursor].action.trigger === TriggerEnum.ONCLICK && this.isOnGoing()) return;
+			
+			$(document).trigger(events.progress, {'target':target, 'index':cursor});
+			var animationSequence = new Array();
 			do {
 				anim = animations[cursor++];
-				anim.play(target, false, false);
-				$(document).trigger(events.progress, {'target':target, 'index':cursor-1});
-				if(cursor < anims.length && animations[cursor].action.trigger === TriggerEnum.ONCLICK) {
+				animationSequence.push(anim);
+				
+				if(cursor < anims.length && animations[cursor].action.trigger !== TriggerEnum.WITHPREVIOUS) {
 					break;
 				}
 			} while(cursor < anims.length);
-            if(cursor === anims.length) {
-				$(document).trigger(events.completed, {'target':target});
-			}
+			this.play(animationSequence, false, false);
         } else {
             $(document).trigger(events.completed, {'target':target});
         }
     }
 	
 	/*
-		Move to previous animation.
+		Move to the previous state (right before the next (from past to future) onClick-triggered action).
 		*/
 	this.prev = function() {
 		if( cursor > 0 ) {
+			// if an action ongoing, prevent the previous action from playing
+			if(this.isOnGoing()) return;
+			
+			$(document).trigger(events.progressReverse, {'target':target, 'index':cursor});
+			var animationSequence = new Array();
 			do {
 				anim = animations[--cursor];
-				anim.play(target, true, false);
-				$(document).trigger(events.progress, {'target':target, 'index':cursor-1});
+				animationSequence.push(anim);
 				
 				if(cursor > 0 && animations[cursor].action.trigger === TriggerEnum.ONCLICK) {
 					break;
@@ -117,17 +168,11 @@ function Animator(target, animations) {
 			if(cursor === 0) {
 				$(document).trigger(events.completedReverse, {'target':target});
 			}
+			this.play(animationSequence, true, true);
         } else {
             $(document).trigger(events.completedReverse, {'target':target});
         }
 	}
-   
-    /*  
-        Return true if animation is complete.
-        */
-    this.isCompleted = function() {
-        return cursor == anims.length;
-    }
     
     /*
         Push new animation into the animator.
@@ -135,14 +180,57 @@ function Animator(target, animations) {
     this.push = function(anim) {
         this.anims.push(anim);
     }
+	
+	/*
+		Continue the current sequence of animations.
+		*/
+	this.continuePlaying = function(action, reverse) {
+		// find the index of the current action in animations
+		curInd = -1;
+		for(i = 0; i < animations.length; ++i) {
+			if(animations[i].action.id === action.id) {
+				curInd = i;
+				break;
+			}
+		}
+		
+		if(curInd === -1) return;
+
+		
+		if(reverse) {
+			if(action.trigger != TriggerEnum.ONCLICK) {
+				this.prev();
+			}
+		} else {
+			// play the next sequence automatically if the next key (non-withPrevious) action is triggered on afterPrevious
+			// find next key animation
+			nextInd = curInd+1;
+			while(nextInd < animations.length && animations[nextInd].action.trigger === TriggerEnum.WITHPREVIOUS) {
+				++nextInd;
+			}
+			// stop if the sequence of automatically playing actions is finished
+			if(nextInd >= animations.length || animations[nextInd].action.trigger === TriggerEnum.ONCLICK) {
+				return;
+			}
+			
+			this.next();
+		}
+	}
     
-    function init() {           
+    this.init = function() {           
         $(document).trigger(events.beforeInitialize, {'target':target});
         
         cursor = 0;
         if( anims.length>0 ) {
+			for(i = 0; i < animations.length; ++i) {
+				animations[i].action.animator = this;
+			}
 			anim = animations[cursor];
-            $(document).trigger(events.initialize, {'target':target});   
+            $(document).trigger(events.initialize, {'target':target}); 
+			// autostart if necessary
+			if(anim.action.trigger !== TriggerEnum.ONCLICK) {
+				this.next();
+			}
         } else {
             throw "Animator requires at least one animation."
         }
@@ -160,14 +248,11 @@ function Animator(target, animations) {
     a   current action JSON descriptor
     nextA   action JSON descriptor following the current one
     */
-Animator.Appear = function(prevA, a, nextA) {
-	return generateChainedAnimation(prevA, a, nextA, function(t, reverse, skip) {
-		this.appearance = function() {
-			playRevertibleAnimation(a.target, t, 
-				{opacity: 1}, {opacity: 0}, 
-				a.duration, reverse, skip);
-		};
-		callUsingTrigger(this.appearance, prevA, a, nextA, t, reverse);
+Animator.Appear = function(ind, prevA, a, nextA) {
+	return generateChainedAnimation(ind, prevA, a, nextA, function(t, reverse, skip) {
+		playRevertibleAnimation(a, t, 
+			{opacity: 1}, {opacity: 0}, 
+			reverse, skip);
 	});
 }
 
@@ -178,14 +263,11 @@ Animator.Appear = function(prevA, a, nextA) {
     a   current action JSON descriptor
     nextA   action JSON descriptor following the current one
     */
-Animator.Disappear = function(prevA, a, nextA) {
-	return generateChainedAnimation(prevA, a, nextA, function(t, reverse, skip) {
-		this.disappearance = function() {
-			playRevertibleAnimation(a.target, t, 
-				{opacity: 0}, {opacity: 1}, 
-				a.duration, reverse, skip);
-		};
-		callUsingTrigger(this.disappearance, prevA, a, nextA, t, reverse);
+Animator.Disappear = function(ind, prevA, a, nextA) {
+	return generateChainedAnimation(ind, prevA, a, nextA, function(t, reverse, skip) {
+		playRevertibleAnimation(a, t, 
+			{opacity: 0}, {opacity: 1}, 
+			reverse, skip);
 	});
 }
 
@@ -196,22 +278,19 @@ Animator.Disappear = function(prevA, a, nextA) {
     a   current action JSON descriptor
     nextA   action JSON descriptor following the current one
     */
-Animator.Move = function(prevA, a, nextA) {
-	return generateChainedAnimation(prevA, a, nextA, function(t, reverse, skip) {
+Animator.Move = function(ind, prevA, a, nextA) {
+	return generateChainedAnimation(ind, prevA, a, nextA, function(t, reverse, skip) {
 		// One needs to wait for the animation to be finished to avoid using the wrong starting coordinates
-		this.translation = function() {
-			$(a.target, t).promise().done(function(){
-				currentX = parseInt($(a.target).css("left"));
-				currentY = parseInt($(a.target).css("top"));
-				trX = parseInt(a.trX);
-				trY = parseInt(a.trY);
-				playRevertibleAnimation(a.target, t, 
-					{left: currentX+trX, top: currentY+trY}, 
-					{left: currentX-trX, top: currentY-trY}, 
-					a.duration, reverse, skip);
-			});
-		}
-		callUsingTrigger(this.translation, prevA, a, nextA, t, reverse);
+		$(a.target, t).promise().done(function(){
+			currentX = parseInt($(a.target).css("left"));
+			currentY = parseInt($(a.target).css("top"));
+			trX = parseInt(a.trX);
+			trY = parseInt(a.trY);
+			playRevertibleAnimation(a, t, 
+				{left: currentX+trX, top: currentY+trY}, 
+				{left: currentX-trX, top: currentY-trY}, 
+				reverse, skip);
+		});
 	});
 }
 
@@ -221,52 +300,34 @@ Animator.Move = function(prevA, a, nextA) {
 ///////////////////////////////////////////////////////////
 
 /*
-    Call the animation function depending on the triggers and playing order.
-    */
-callUsingTrigger = function(func, prevAction, action, nextAction, container, reverse) {
-	if(reverse) {
-		if(nextAction !== undefined && nextAction.trigger === TriggerEnum.AFTERPREVIOUS) {
-			// wait until the previous (reverse) animation is done
-			$(nextAction.target, container).promise().done(function(){
-				func();
-			});
-		} else {
-			func();
-		}
-	} else {
-		if(prevAction !== undefined && action.trigger === TriggerEnum.AFTERPREVIOUS) {
-			// wait until the previous animation is done
-			$(prevAction.target, container).promise().done(function(){
-				func();
-			});
-		} else {
-			func();
-		}
-	}
-}
-
-/*
 	Animate the target element depending on various playing options.
 	*/
-playRevertibleAnimation = function(e, t, 
+playRevertibleAnimation = function(a, t, 
 		cssProperty, reverseCssProperty, 
-		duration, reverse, skip) {
-
-	d = duration;
+		reverse, skip) {
+	a.playing = true;
+	d = a.duration;
 	if(d === undefined || skip) d = 0;
 	if(reverse) {
-		$(e, t).animate(reverseCssProperty, d);
+		$(a.target, t).animate(reverseCssProperty, d);
 	} else {
-		$(e, t).animate(cssProperty, d);
+		$(a.target, t).animate(cssProperty, d);
 	}
+	$(a.target, t).promise().done(function(){
+		a.playing = false;
+		if(a.trigger !== TriggerEnum.WITHPREVIOUS && !reverse && !skip) {
+			a.animator.continuePlaying(a, reverse);	
+		}
+	});
 }
 
 /*
 	Generates an object containing information about the current animation, 
 	how to play it, and information about the next and previous animations.
 	*/
-generateChainedAnimation = function(prevA, currentA, nextA, currentAnimFunc) {
+generateChainedAnimation = function(ind, prevA, currentA, nextA, currentAnimFunc) {
 	return {
+		index: ind,
 		action: currentA,
 		prevAction: prevA,
 		nextAction: nextA,

--- a/extensions/animator/animator.js
+++ b/extensions/animator/animator.js
@@ -1,7 +1,7 @@
 function Animator(target, animations) {
 
 	TriggerEnum = {
-		ONCLICK: "onClick",
+		ONCHANGE: "onChange",
 		WITHPREVIOUS: "withPrevious",
 		AFTERPREVIOUS: "afterPrevious"
 	}
@@ -24,30 +24,39 @@ function Animator(target, animations) {
 		
 		/*
 		This event fires whenever a sequence of animations is performed. The callback
-                function is passed three parameters, target, index and reverse, equal to
+                function is passed three parameters, target, id and reverse, equal to
                 the target on which the animation is performed, the id of
                 the animation, and a boolean equal to true if the animation has been 
 				performed in reverse order
 		*/
-		progress: 'deck.animator.progress',
+		sequenceStart: 'deck.animator.sequence.start',
+		
+		/*
+		This event fires whenever a sequence of animations has finished performing. The callback
+                function is passed three parameters, target, id and reverse, equal to
+                the target on which the animation is performed, the id of
+                the animation, and a boolean equal to true if the animation has been 
+				performed in reverse order
+		*/
+		sequenceStop: 'deck.animator.sequence.stop',
 		
 		/*
 		This event fires whenever a single action is performed. The callback function
-				is passed three parameters, target, index and reverse, equal to
+				is passed three parameters, target, id and reverse, equal to
                 the target on which the animation is performed, the id of
                 the animation, and a boolean equal to true if the animation has been 
 				performed in reverse order
 		*/
-		perform: 'deck.animator.perform',
+		actionStart: 'deck.animator.action.start',
 		
 		/*
 		This event fires whenever a single action has finished performing. The callback function
-				is passed three parameters, target, index and reverse, equal to
+				is passed three parameters, target, id and reverse, equal to
                 the target on which the animation is performed, the id of
                 the animation, and a boolean equal to true if the animation has been 
 				performed in reverse order
 		*/
-		performed: 'deck.animator.performed',
+		actionStop: 'deck.animator.action.stop',
                 
 		/*
 		This event fires at the beginning of deck.animator initialization.
@@ -125,8 +134,8 @@ function Animator(target, animations) {
 		}
 		// else, do the actual next stuff
         if( cursor < anims.length ) {
-			$(document).trigger(events.progress, {'target':target, 'id':animations[cursor].action.id, 'reverse':false});
 			var animationSequence = new Array();
+			$(document).trigger(events.sequenceStart, {'target':target, 'id':animations[cursor].action.id, 'reverse':false});
 			do {
 				anim = animations[cursor++];
 				animationSequence.push(anim);
@@ -135,7 +144,7 @@ function Animator(target, animations) {
 					break;
 				}
 			} while(cursor < anims.length);
-			playSequence(animationSequence, false, false);
+			playSequence(this, animationSequence, false, false);
 			if(cursor === anims.length) {
 				$(document).trigger(events.completed, {'target':target, 'reverse':false});
 			}
@@ -154,9 +163,9 @@ function Animator(target, animations) {
 				this.finishOngoing();
 				return;
 			}
-			
-			$(document).trigger(events.progress, {'target':target, 'index':animations[cursor-1].action.id, 'reverse':true});
+
 			var animationSequence = new Array();
+			$(document).trigger(events.sequenceStart, {'target':target, 'index':animations[cursor-1].action.id, 'reverse':true});
 			do {
 				anim = animations[--cursor];
 				animationSequence.push(anim);
@@ -168,7 +177,7 @@ function Animator(target, animations) {
 			if(cursor === 0) {
 				$(document).trigger(events.completed, {'target':target, 'reverse':true});
 			}
-			playSequence(animationSequence, true, true);
+			playSequence(this, animationSequence, true, true);
         } else {
             $(document).trigger(events.completed, {'target':target, 'reverse':true});
         }
@@ -183,14 +192,14 @@ function Animator(target, animations) {
 		});
 	}
 	
-		/*
+	/*
 		Add a callback to animationSequence[i].
 		*/
-	function queueAnimation(animationSequence, i, reverse, skip) {
+	function queueAnimation(animator, animationSequence, i, reverse, skip) {
 		animationSequence[i].action.nextPlay = function() {
-			$(document).trigger(events.performed, {'target':target, 'id':animationSequence[i].action.id, 'reverse':reverse});
+			$(document).trigger(events.actionStop, {'target':target, 'id':animationSequence[i].action.id, 'reverse':reverse});
 			if(i < animationSequence.length - 1 &&
-					(animationSequence[i].action.trigger !== TriggerEnum.WITHPREVIOUS 
+					(animationSequence[i].action.trigger === TriggerEnum.ONCHANGE 
 						|| animationSequence[i+1].action.trigger === TriggerEnum.AFTERPREVIOUS)) {
 				playAnimation(animationSequence[i+1], reverse, skip);
 				for(j = i+2; j < animationSequence.length ; ++j) {
@@ -199,6 +208,10 @@ function Animator(target, animations) {
 					}
 				}
 			}
+			
+			if(!animator.isOngoing()) {
+				$(document).trigger(events.sequenceStop, {'target':target, 'id':animationSequence[i].action.id, 'reverse':reverse});
+			}
 		};
 	}
 	
@@ -206,14 +219,14 @@ function Animator(target, animations) {
 		Play a single action.
 		*/
 	function playAnimation(animation, reverse, skip) {
-		$(document).trigger(events.perform, {'target':target, 'id':animation.action.id, 'reverse':reverse});
+		$(document).trigger(events.actionStart, {'target':target, 'id':animation.action.id, 'reverse':reverse});
 		animation.play(target, reverse, skip);
 	}
 	
 	/*
 		Play a sequence of animation
 		*/
-	function playSequence(animationSequence, reverse, skip) {
+	function playSequence(animator, animationSequence, reverse, skip) {
 		if(animationSequence.length === 0) return;
 		
 		if(reverse) {
@@ -221,8 +234,8 @@ function Animator(target, animations) {
 				playAnimation(a, reverse, skip);
 			});
 		} else {
-			for(i = 0; i < animationSequence.length - 1; ++i) {
-				queueAnimation(animationSequence, i, reverse, skip);
+			for(i = 0; i < animationSequence.length; ++i) {
+				queueAnimation(animator, animationSequence, i, reverse, skip);
 			}
 			playAnimation(animationSequence[0], reverse, skip);
 		}

--- a/extensions/animator/animator.js
+++ b/extensions/animator/animator.js
@@ -52,6 +52,10 @@ function Animator(target, animations) {
     this.restart = function() {
         init();
     }
+	
+	this.getCursor = function() {
+		return cursor;
+	}
 
     /*  
         Move to next animation.
@@ -59,18 +63,25 @@ function Animator(target, animations) {
     this.next = function() {
         if( cursor < anims.length ) {
             anim = animations[cursor++];
-            if( $.isArray(anim) ) {
-                $(anim).each( function() {
-                    this(target);
-                });
-            } else {
-                anim(target);
-            }
+            anim(target, false);
             $(document).trigger(events.progress, {'target':target, 'index':cursor-1});
         } else {
             $(document).trigger(events.completed, {'target':target});
         }
     }
+	
+	/*
+		Move to previous animation.
+		*/
+	this.prev = function() {
+		if( cursor > 0 ) {
+			anim = animations[--cursor];
+			anim(target, true);
+			$(document).trigger(events.progress, {'target':target, 'index':cursor-1});
+        } else {
+            $(document).trigger(events.completed, {'target':target});
+        }
+	}
    
     /*  
         Return true if animation is complete.
@@ -93,13 +104,7 @@ function Animator(target, animations) {
         cursor = 0;
         if( anims.length>0 ) {
             anim = animations[cursor++];
-            if( $.isArray(anim) ) {
-                $(anim).each( function() {
-                    this(target);
-                });
-            } else {
-                anim(target);
-            }
+            anim(target, false);
             
             $(document).trigger(events.initialize, {'target':target});   
         } else {
@@ -116,8 +121,12 @@ function Animator(target, animations) {
     */
 Animator.Appear = function(e, d) {
     d = d || 0;
-    return function() {
-		$(e).animate({opacity: 1}, d);
+    return function(t, reverse) {
+		if(reverse) {
+			$(e, t).animate({opacity: 0}, d);
+		} else {
+			$(e, t).animate({opacity: 1}, d);
+		}
     }
 }
 
@@ -129,8 +138,12 @@ Animator.Appear = function(e, d) {
     */
 Animator.Disappear = function(e, d) {
     d = d || 0;
-    return function() {
-		$(e).animate({opacity: 0}, d);
+    return function(t, reverse) {
+		if(reverse) {
+			$(e, t).animate({opacity: 1}, d);
+		} else {
+			$(e, t).animate({opacity: 0}, d);
+		}
     }
 }
 
@@ -141,13 +154,16 @@ Animator.Disappear = function(e, d) {
     tr  the transformation
     d   duration
     */
-Animator.Transform = function(e,tr,d) {
+Animator.Move = function(e,trX,trY,d) {
     d = d || 0;
-    return function(t) {
-        var $svg = $(t).svg('get');
-        $(e, $svg.root()).each( function(){
-            $(this).animate({'svgTransform': tr}, d);
-        })
+    return function(t, reverse) {
+		currentX = parseInt($(e).css("left"));
+		currentY = parseInt($(e).css("top"));
+		if(reverse) {
+			$(e, t).animate({left: currentX-trX, top: currentY-trY}, d);
+		} else {
+			$(e, t).animate({left: currentX+trX, top: currentY+trY}, d);
+		}
     }
 }
 

--- a/extensions/animator/animator.js
+++ b/extensions/animator/animator.js
@@ -11,38 +11,43 @@ function Animator(target, animations) {
     
     events = {
 		/*
-		This event fires whenever the current animation is completed.
-                The callback function is passed one parameter, target, equal to 
-                the target on which the animation completed.
+		This event fires whenever the current animation is has nothing left to start playing.
+                The callback function is passed two parameters, target, equal to 
+                the target on which the animation completed, and reverse, 
+				true if the animation has been completed in reverse order
 		
-		$(document).bind('deck.animator.completed', function(target) {
+		$(document).bind('deck.animator.completed', function(target, reverse) {
 		   alert('The animation of '+target+' has just completed.');
 		});
 		*/
 		completed: 'deck.animator.completed',
 		
 		/*
-		This event fires whenever the current animation has finished playing in reverse.
-                The callback function is passed one parameter, target, equal to 
-                the target on which the animation completed.
-		*/
-		completedReverse: 'deck.animator.completedReverse',
-		
-		/*
 		This event fires whenever a sequence of animations is performed. The callback
-                function is passed two parameters, target and index, equal to
-                the target on which the animation is performed and the index of
-                the animation i.e between 0 and animation.lenght.
+                function is passed three parameters, target, index and reverse, equal to
+                the target on which the animation is performed, the id of
+                the animation, and a boolean equal to true if the animation has been 
+				performed in reverse order
 		*/
 		progress: 'deck.animator.progress',
 		
 		/*
-		This event fires whenever a sequence of reverse animations is performed. The callback
-                function is passed two parameters, target and index, equal to
-                the target on which the animation is performed and the index of
-                the animation i.e between 0 and animation.lenght.
+		This event fires whenever a single action is performed. The callback function
+				is passed three parameters, target, index and reverse, equal to
+                the target on which the animation is performed, the id of
+                the animation, and a boolean equal to true if the animation has been 
+				performed in reverse order
 		*/
-		progressReverse: 'deck.animator.progressReverse',
+		perform: 'deck.animator.perform',
+		
+		/*
+		This event fires whenever a single action has finished performing. The callback function
+				is passed three parameters, target, index and reverse, equal to
+                the target on which the animation is performed, the id of
+                the animation, and a boolean equal to true if the animation has been 
+				performed in reverse order
+		*/
+		performed: 'deck.animator.performed',
                 
 		/*
 		This event fires at the beginning of deck.animator initialization.
@@ -66,7 +71,7 @@ function Animator(target, animations) {
         Restart animator.
         */
     this.restart = function() {
-        this.init();
+        init();
 		this.next(false);
     }
 	
@@ -74,19 +79,12 @@ function Animator(target, animations) {
 		Start animator from the last state.
 		*/
 	this.startFromTheEnd = function() {
-		this.init();
+		init();
 		animations.forEach( function(a){
-            a.play(target, false, true);
+            playAnimation(a, false, true);
 			cursor++;
         });
-		$(document).trigger(events.completed, {'target':target});
-	}
-	
-	/*
-		Finish a given animation.
-		*/
-	this.finishAnimation = function(action) {
-		$(action.target, target).finish();
+		$(document).trigger(events.completed, {'target':target, 'reverse':true});
 	}
 	
 	/*
@@ -105,79 +103,49 @@ function Animator(target, animations) {
 	
 	/*
 		Return true if the animation is ongoing
-			*/
+		*/
 	this.isOngoing = function() {
-		for(i = 0; i < animations.length; ++i) {
+		for(var i = 0; i < animations.length; ++i) {
 			if($(animations[i].action.target, target).is(':animated')) {
 				return true;
 			}
 		}
 		return false;
 	}
-	
-	/*
-		Play a sequence of animation.
-		*/
-	this.play = function(animationSequence, isReversed, skip) {
-		if(animationSequence.length === 0) return;
-		var lastPlayed = 0;
-		animationSequence[0].play(target, isReversed, skip);
-		for(i = 1; i < animationSequence.length && (animationSequence[i].action.trigger === TriggerEnum.WITHPREVIOUS || isReversed); ++i) {
-			animationSequence[i].play(target, isReversed, skip);
-			lastPlayed = i;
-		}
-		if(animationSequence[lastPlayed].index === animations.length && !isReversed) {
-			$(document).trigger(events.completed, {'target':target});
-		}
-		if(animationSequence[lastPlayed].index === 0 && isReversed) {
-			$(document).trigger(events.completedReverse, {'target':target});
-		}
-	}
-	
-	/*
-		Finish all ongoing animations
-		*/
-	this.finishOngoing = function() {
-		var self = this;
-		animations.forEach(function(a){
-			self.finishAnimation(a.action);
-		});
-	}
 
     /*  
         Move to the next state (right before an afterPrevious-triggered action and, 
-		by extension by calling this.play, right before the next onClick-triggered action).
+		by extension by calling playSequence, right before the next onChange-triggered action).
         */
     this.next = function(verifyOngoing) {
 		// if a sequence of action is ongoing, cut the animation short on key press
 		if(verifyOngoing && this.isOngoing()) {
-			console.log("ongoing");
 			this.finishOngoing();
-			while(cursor < animations.length && animations[cursor].action.trigger !== TriggerEnum.ONCLICK) {
-				animations[cursor++].play(target, false, true);
-			}
 			return;
 		}
 		// else, do the actual next stuff
         if( cursor < anims.length ) {
-			$(document).trigger(events.progress, {'target':target, 'index':cursor});
+			$(document).trigger(events.progress, {'target':target, 'id':animations[cursor].action.id, 'reverse':false});
 			var animationSequence = new Array();
 			do {
 				anim = animations[cursor++];
 				animationSequence.push(anim);
 				
-				if(cursor < anims.length && animations[cursor].action.trigger !== TriggerEnum.WITHPREVIOUS) {
+				if(cursor < anims.length && animations[cursor].action.trigger === TriggerEnum.ONCHANGE) {
 					break;
 				}
 			} while(cursor < anims.length);
-			this.play(animationSequence, false, false);
+			playSequence(animationSequence, false, false);
+			if(cursor === anims.length) {
+				$(document).trigger(events.completed, {'target':target, 'reverse':false});
+			}
         } else {
-            $(document).trigger(events.completed, {'target':target});
+            $(document).trigger(events.completed, {'target':target, 'reverse':false});
         }
     }
 	
 	/*
-		Move to the previous state (right before the next (from past to future) onClick-triggered action).
+		Move to the previous state (right before the next (from past to future) onChange-triggered action).
 		*/
 	this.prev = function(verifyOngoing) {
 		if( cursor > 0 ) {
@@ -187,82 +155,86 @@ function Animator(target, animations) {
 				return;
 			}
 			
-			$(document).trigger(events.progressReverse, {'target':target, 'index':cursor});
+			$(document).trigger(events.progress, {'target':target, 'index':animations[cursor-1].action.id, 'reverse':true});
 			var animationSequence = new Array();
 			do {
 				anim = animations[--cursor];
 				animationSequence.push(anim);
 				
-				if(cursor > 0 && animations[cursor].action.trigger === TriggerEnum.ONCLICK) {
+				if(cursor > 0 && animations[cursor].action.trigger === TriggerEnum.ONCHANGE) {
 					break;
 				}
 			} while(cursor > 0);
 			if(cursor === 0) {
-				$(document).trigger(events.completedReverse, {'target':target});
+				$(document).trigger(events.completed, {'target':target, 'reverse':true});
 			}
-			this.play(animationSequence, true, true);
+			playSequence(animationSequence, true, true);
         } else {
-            $(document).trigger(events.completedReverse, {'target':target});
+            $(document).trigger(events.completed, {'target':target, 'reverse':true});
         }
 	}
-    
-    /*
-        Push new animation into the animator.
-        */
-    this.push = function(anim) {
-        this.anims.push(anim);
-    }
 	
 	/*
-		Continue the current sequence of animations.
+		Finish immediatly all ongoing animations
 		*/
-	this.continuePlaying = function(action, reverse) {
-		// find the index of the current action in animations
-		curInd = -1;
-		for(i = 0; i < animations.length; ++i) {
-			if(animations[i].action.id === action.id) {
-				curInd = i;
-				break;
+	this.finishOngoing = function() {
+		animations.forEach(function(a){
+			$(a.action.target, target).finish();
+		});
+	}
+	
+		/*
+		Add a callback to animationSequence[i].
+		*/
+	function queueAnimation(animationSequence, i, reverse, skip) {
+		animationSequence[i].action.nextPlay = function() {
+			$(document).trigger(events.performed, {'target':target, 'id':animationSequence[i].action.id, 'reverse':reverse});
+			if(i < animationSequence.length - 1 &&
+					(animationSequence[i].action.trigger !== TriggerEnum.WITHPREVIOUS 
+						|| animationSequence[i+1].action.trigger === TriggerEnum.AFTERPREVIOUS)) {
+				playAnimation(animationSequence[i+1], reverse, skip);
+				for(j = i+2; j < animationSequence.length ; ++j) {
+					if(animationSequence[j].action.trigger === TriggerEnum.WITHPREVIOUS) {
+						playAnimation(animationSequence[j], reverse, skip);
+					}
+				}
 			}
-		}
-		
-		if(curInd === -1) return;
-
+		};
+	}
+	
+	/*
+		Play a single action.
+		*/
+	function playAnimation(animation, reverse, skip) {
+		$(document).trigger(events.perform, {'target':target, 'id':animation.action.id, 'reverse':reverse});
+		animation.play(target, reverse, skip);
+	}
+	
+	/*
+		Play a sequence of animation
+		*/
+	function playSequence(animationSequence, reverse, skip) {
+		if(animationSequence.length === 0) return;
 		
 		if(reverse) {
-			if(action.trigger != TriggerEnum.ONCLICK) {
-				this.prev(false);
-			}
+			animationSequence.forEach(function(a){
+				playAnimation(a, reverse, skip);
+			});
 		} else {
-			// play the next sequence automatically if the next key (non-withPrevious) action is triggered on afterPrevious
-			// find next key animation
-			nextInd = curInd+1;
-			while(nextInd < animations.length && animations[nextInd].action.trigger === TriggerEnum.WITHPREVIOUS) {
-				++nextInd;
+			for(i = 0; i < animationSequence.length - 1; ++i) {
+				queueAnimation(animationSequence, i, reverse, skip);
 			}
-			// stop if the sequence of automatically playing actions is finished
-			if(nextInd >= animations.length || animations[nextInd].action.trigger === TriggerEnum.ONCLICK) {
-				return;
-			}
-			
-			this.next(false);
+			playAnimation(animationSequence[0], reverse, skip);
 		}
 	}
     
-    this.init = function() {           
+    function init() {           
         $(document).trigger(events.beforeInitialize, {'target':target});
         
         cursor = 0;
         if( anims.length>0 ) {
-			for(i = 0; i < animations.length; ++i) {
-				animations[i].action.animator = this;
-			}
 			anim = animations[cursor];
             $(document).trigger(events.initialize, {'target':target}); 
-			// autostart if necessary
-			if(anim.action.trigger !== TriggerEnum.ONCLICK) {
-				this.next(false);
-			}
         } else {
             throw "Animator requires at least one animation."
         }
@@ -276,12 +248,11 @@ function Animator(target, animations) {
 /*
     Animator.Appear(prevA, a, nextA)
 
-	ind   index of the action in the corresponding JSON animator array
     a   current action JSON descriptor
     */
-Animator.Appear = function(ind, a) {
-	return generateChainedAnimation(ind, a, function(t, reverse, skip) {
-		playRevertibleAnimation(a, t, 
+Animator.Appear = function(a) {
+	return generateAnimatedAction(a, function(t, reverse, skip) {
+		playReversibleAnimation(a, t, 
 			{opacity: 1}, {opacity: 0}, 
 			reverse, skip);
 	});
@@ -290,12 +261,11 @@ Animator.Appear = function(ind, a) {
 /*
     Animator.Disappear(prevA, a, nextA)
 
-	ind   index of the action in the corresponding JSON animator array
     a   current action JSON descriptor
     */
-Animator.Disappear = function(ind, a) {
-	return generateChainedAnimation(ind,  a, function(t, reverse, skip) {
-		playRevertibleAnimation(a, t, 
+Animator.Disappear = function(a) {
+	return generateAnimatedAction(a, function(t, reverse, skip) {
+		playReversibleAnimation(a, t, 
 			{opacity: 0}, {opacity: 1}, 
 			reverse, skip);
 	});
@@ -304,22 +274,18 @@ Animator.Disappear = function(ind, a) {
 /*
     Animator.Move(prevA, a, nextA)
 
-	ind   index of the action in the corresponding JSON animator array
     a   current action JSON descriptor
     */
-Animator.Move = function(ind, a) {
-	return generateChainedAnimation(ind, a, function(t, reverse, skip) {
-		// One needs to wait for the animation to be finished to avoid using the wrong starting coordinates
-		//$(a.target, t).promise().done(function(){
-			currentX = parseInt($(a.target).css("left"));
-			currentY = parseInt($(a.target).css("top"));
-			trX = parseInt(a.trX);
-			trY = parseInt(a.trY);
-			playRevertibleAnimation(a, t, 
-				{left: currentX+trX, top: currentY+trY}, 
-				{left: currentX-trX, top: currentY-trY}, 
-				reverse, skip);
-		//});
+Animator.Move = function(a) {
+	return generateAnimatedAction(a, function(t, reverse, skip) {
+		currentX = parseInt($(a.target).css("left"));
+		currentY = parseInt($(a.target).css("top"));
+		trX = parseInt(a.trX);
+		trY = parseInt(a.trY);
+		playReversibleAnimation(a, t, 
+			{left: currentX+trX, top: currentY+trY}, 
+			{left: currentX-trX, top: currentY-trY}, 
+			reverse, skip);
 	});
 }
 
@@ -331,7 +297,7 @@ Animator.Move = function(ind, a) {
 /*
 	Animate the target element depending on various playing options.
 	*/
-playRevertibleAnimation = function(a, t, 
+playReversibleAnimation = function(a, t, 
 		cssProperty, reverseCssProperty, 
 		reverse, skip) {
 	d = a.duration;
@@ -339,22 +305,16 @@ playRevertibleAnimation = function(a, t,
 	if(reverse) {
 		$(a.target, t).animate(reverseCssProperty, d);
 	} else {
-		$(a.target, t).animate(cssProperty, d);
+		$(a.target, t).animate(cssProperty, d, undefined, a.nextPlay);
 	}
-	$(a.target, t).promise().done(function(){
-		if(a.trigger !== TriggerEnum.WITHPREVIOUS && !reverse && !skip) {
-			a.animator.continuePlaying(a, reverse);	
-		}
-	});
 }
 
 /*
 	Generates an object containing information about the current animation, 
 	how to play it, and information about the next and previous animations.
 	*/
-generateChainedAnimation = function(ind, currentA, currentAnimFunc) {
+generateAnimatedAction = function(currentA, currentAnimFunc) {
 	return {
-		index: ind,
 		action: currentA,
 		play: currentAnimFunc
 	};

--- a/extensions/animator/animator.js
+++ b/extensions/animator/animator.js
@@ -67,7 +67,7 @@ function Animator(target, animations) {
         */
     this.restart = function() {
         this.init();
-		this.next();
+		this.next(false);
     }
 	
 	/*
@@ -83,6 +83,13 @@ function Animator(target, animations) {
 	}
 	
 	/*
+		Finish a given animation.
+		*/
+	this.finishAnimation = function(action) {
+		$(action.target, target).finish();
+	}
+	
+	/*
 		Return true if animation has started playing.
 		*/
 	this.hasStarted = function() {
@@ -90,16 +97,21 @@ function Animator(target, animations) {
 	}
 	
 	/*  
-        Return true if animation is complete.
+        Return true if the animation is finished.
         */
     this.isCompleted = function() {
-        return cursor == anims.length;
+        return cursor == anims.length && !this.isOngoing();
     }
 	
-	this.isOnGoing = function() {
-		animations.forEach(function(a){
-			if(a.action.playing) return true;
-		});
+	/*
+		Return true if the animation is ongoing
+			*/
+	this.isOngoing = function() {
+		for(i = 0; i < animations.length; ++i) {
+			if($(animations[i].action.target, target).is(':animated')) {
+				return true;
+			}
+		}
 		return false;
 	}
 	
@@ -121,16 +133,33 @@ function Animator(target, animations) {
 			$(document).trigger(events.completedReverse, {'target':target});
 		}
 	}
+	
+	/*
+		Finish all ongoing animations
+		*/
+	this.finishOngoing = function() {
+		var self = this;
+		animations.forEach(function(a){
+			self.finishAnimation(a.action);
+		});
+	}
 
     /*  
         Move to the next state (right before an afterPrevious-triggered action and, 
 		by extension by calling this.play, right before the next onClick-triggered action).
         */
-    this.next = function() {
+    this.next = function(verifyOngoing) {
+		// if a sequence of action is ongoing, cut the animation short on key press
+		if(verifyOngoing && this.isOngoing()) {
+			console.log("ongoing");
+			this.finishOngoing();
+			while(cursor < animations.length && animations[cursor].action.trigger !== TriggerEnum.ONCLICK) {
+				animations[cursor++].play(target, false, true);
+			}
+			return;
+		}
+		// else, do the actual next stuff
         if( cursor < anims.length ) {
-			// if a sequence of action is ongoing, prevent the next action from playing
-			if(animations[cursor].action.trigger === TriggerEnum.ONCLICK && this.isOnGoing()) return;
-			
 			$(document).trigger(events.progress, {'target':target, 'index':cursor});
 			var animationSequence = new Array();
 			do {
@@ -150,10 +179,13 @@ function Animator(target, animations) {
 	/*
 		Move to the previous state (right before the next (from past to future) onClick-triggered action).
 		*/
-	this.prev = function() {
+	this.prev = function(verifyOngoing) {
 		if( cursor > 0 ) {
-			// if an action ongoing, prevent the previous action from playing
-			if(this.isOnGoing()) return;
+			// if a sequence of action is ongoing, cut the animation short on key press
+			if(verifyOngoing && this.isOngoing()) {
+				this.finishOngoing();
+				return;
+			}
 			
 			$(document).trigger(events.progressReverse, {'target':target, 'index':cursor});
 			var animationSequence = new Array();
@@ -199,7 +231,7 @@ function Animator(target, animations) {
 		
 		if(reverse) {
 			if(action.trigger != TriggerEnum.ONCLICK) {
-				this.prev();
+				this.prev(false);
 			}
 		} else {
 			// play the next sequence automatically if the next key (non-withPrevious) action is triggered on afterPrevious
@@ -213,7 +245,7 @@ function Animator(target, animations) {
 				return;
 			}
 			
-			this.next();
+			this.next(false);
 		}
 	}
     
@@ -229,7 +261,7 @@ function Animator(target, animations) {
             $(document).trigger(events.initialize, {'target':target}); 
 			// autostart if necessary
 			if(anim.action.trigger !== TriggerEnum.ONCLICK) {
-				this.next();
+				this.next(false);
 			}
         } else {
             throw "Animator requires at least one animation."
@@ -244,12 +276,11 @@ function Animator(target, animations) {
 /*
     Animator.Appear(prevA, a, nextA)
 
-	prevA   action JSON descriptor preceding the current one
+	ind   index of the action in the corresponding JSON animator array
     a   current action JSON descriptor
-    nextA   action JSON descriptor following the current one
     */
-Animator.Appear = function(ind, prevA, a, nextA) {
-	return generateChainedAnimation(ind, prevA, a, nextA, function(t, reverse, skip) {
+Animator.Appear = function(ind, a) {
+	return generateChainedAnimation(ind, a, function(t, reverse, skip) {
 		playRevertibleAnimation(a, t, 
 			{opacity: 1}, {opacity: 0}, 
 			reverse, skip);
@@ -259,12 +290,11 @@ Animator.Appear = function(ind, prevA, a, nextA) {
 /*
     Animator.Disappear(prevA, a, nextA)
 
-	prevA   action JSON descriptor preceding the current one
+	ind   index of the action in the corresponding JSON animator array
     a   current action JSON descriptor
-    nextA   action JSON descriptor following the current one
     */
-Animator.Disappear = function(ind, prevA, a, nextA) {
-	return generateChainedAnimation(ind, prevA, a, nextA, function(t, reverse, skip) {
+Animator.Disappear = function(ind, a) {
+	return generateChainedAnimation(ind,  a, function(t, reverse, skip) {
 		playRevertibleAnimation(a, t, 
 			{opacity: 0}, {opacity: 1}, 
 			reverse, skip);
@@ -274,14 +304,13 @@ Animator.Disappear = function(ind, prevA, a, nextA) {
 /*
     Animator.Move(prevA, a, nextA)
 
-	prevA   action JSON descriptor preceding the current one
+	ind   index of the action in the corresponding JSON animator array
     a   current action JSON descriptor
-    nextA   action JSON descriptor following the current one
     */
-Animator.Move = function(ind, prevA, a, nextA) {
-	return generateChainedAnimation(ind, prevA, a, nextA, function(t, reverse, skip) {
+Animator.Move = function(ind, a) {
+	return generateChainedAnimation(ind, a, function(t, reverse, skip) {
 		// One needs to wait for the animation to be finished to avoid using the wrong starting coordinates
-		$(a.target, t).promise().done(function(){
+		//$(a.target, t).promise().done(function(){
 			currentX = parseInt($(a.target).css("left"));
 			currentY = parseInt($(a.target).css("top"));
 			trX = parseInt(a.trX);
@@ -290,7 +319,7 @@ Animator.Move = function(ind, prevA, a, nextA) {
 				{left: currentX+trX, top: currentY+trY}, 
 				{left: currentX-trX, top: currentY-trY}, 
 				reverse, skip);
-		});
+		//});
 	});
 }
 
@@ -305,7 +334,6 @@ Animator.Move = function(ind, prevA, a, nextA) {
 playRevertibleAnimation = function(a, t, 
 		cssProperty, reverseCssProperty, 
 		reverse, skip) {
-	a.playing = true;
 	d = a.duration;
 	if(d === undefined || skip) d = 0;
 	if(reverse) {
@@ -314,7 +342,6 @@ playRevertibleAnimation = function(a, t,
 		$(a.target, t).animate(cssProperty, d);
 	}
 	$(a.target, t).promise().done(function(){
-		a.playing = false;
 		if(a.trigger !== TriggerEnum.WITHPREVIOUS && !reverse && !skip) {
 			a.animator.continuePlaying(a, reverse);	
 		}
@@ -325,12 +352,10 @@ playRevertibleAnimation = function(a, t,
 	Generates an object containing information about the current animation, 
 	how to play it, and information about the next and previous animations.
 	*/
-generateChainedAnimation = function(ind, prevA, currentA, nextA, currentAnimFunc) {
+generateChainedAnimation = function(ind, currentA, currentAnimFunc) {
 	return {
 		index: ind,
 		action: currentA,
-		prevAction: prevA,
-		nextAction: nextA,
 		play: currentAnimFunc
 	};
 }

--- a/extensions/animator/animator.js
+++ b/extensions/animator/animator.js
@@ -1,9 +1,10 @@
-/* 
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
- */
-
 function Animator(target, animations) {
+
+	TriggerEnum = {
+		ONCLICK: "onClick",
+		WITHPREVIOUS: "withPrevious",
+		AFTERPREVIOUS: "afterPrevious"
+	}
     
     var anims,  // list of all animations
     cursor,     // pointer to the current animation
@@ -60,7 +61,8 @@ function Animator(target, animations) {
 	this.startFromTheEnd = function() {
 		init();
 		animations.forEach( function(a){
-            a(target, false, true);
+			console.log("startFromEnd");
+            a.play(target, false, true);
 			cursor++;
         });
 	}
@@ -74,8 +76,14 @@ function Animator(target, animations) {
         */
     this.next = function() {
         if( cursor < anims.length ) {
-            anim = animations[cursor++];
-            anim(target, false, false);
+			do {
+				anim = animations[cursor++];
+				anim.play(target, false, false);
+				
+				if(cursor < anims.length && animations[cursor].trigger === TriggerEnum.ONCLICK) {
+					break;
+				}
+			} while(cursor < anims.length);
             $(document).trigger(events.progress, {'target':target, 'index':cursor-1});
         } else {
             $(document).trigger(events.completed, {'target':target});
@@ -87,8 +95,14 @@ function Animator(target, animations) {
 		*/
 	this.prev = function() {
 		if( cursor > 0 ) {
-			anim = animations[--cursor];
-			anim(target, true, false);
+			do {
+				anim = animations[--cursor];
+				anim.play(target, true, false);
+				
+				if(cursor > 0 && animations[cursor].trigger === TriggerEnum.ONCLICK) {
+					break;
+				}
+			} while(cursor > 0);
 			$(document).trigger(events.progress, {'target':target, 'index':cursor-1});
         } else {
             $(document).trigger(events.completed, {'target':target});
@@ -122,23 +136,54 @@ function Animator(target, animations) {
     }
 }
 
+callUsingTrigger = function(func, trigger, previousElt, nextElt, nextTrigger, container, reverse) {
+	if(reverse) {
+		if(nextTrigger === TriggerEnum.AFTERPREVIOUS && nextElt !== undefined) {
+			// wait until the previous (reverse) animation is done
+			$(nextElt, container).promise().done(function(){
+				func();
+			});
+		} else {
+			func();
+		}
+	} else {
+		if(trigger === TriggerEnum.AFTERPREVIOUS && previousElt !== undefined) {
+			// wait until the previous animation is done
+			$(previousElt, container).promise().done(function(){
+				func();
+			});
+		} else {
+			func();
+		}
+	}
+}
+
 /*
     Animator.Appear(e,d)
 
     e   element
     d   duration
+	previousElt   the id of the previous Elt
+	nextElt   the id of the next Elt
+	trig   the stirng representing the trigger of the event
     */
-Animator.Appear = function(e, d) {
+Animator.Appear = function(e, d, previousElt, nextElt, nextTrigger, trig) {
     d = d || 0;
-    return function(t, reverse, skip) {
-		duration = d;
-		if(skip) duration = 0;
-		if(reverse) {
-			$(e, t).animate({opacity: 0}, duration);
-		} else {
-			$(e, t).animate({opacity: 1}, duration);
+	return {
+		trigger: trig,
+		play: function(t, reverse, skip) {
+			duration = d;
+			if(skip) duration = 0;
+			this.appearance = function() {
+				if(reverse) {
+					$(e, t).animate({opacity: 0}, duration);
+				} else {
+					$(e, t).animate({opacity: 1}, duration);
+				}
+			};
+			callUsingTrigger(this.appearance, this.trigger, previousElt, nextElt, nextTrigger, t, reverse);
 		}
-    }
+	};
 }
 
 /*
@@ -146,18 +191,27 @@ Animator.Appear = function(e, d) {
 
     e   element
     d   duration
+	previousElt   the id of the previous Elt
+	nextElt   the id of the next Elt
+	trig   the stirng representing the trigger of the event
     */
-Animator.Disappear = function(e, d) {
+Animator.Disappear = function(e, d, previousElt, nextElt, nextTrigger, trig) {
     d = d || 0;
-    return function(t, reverse, skip) {
-		duration = d;
-		if(skip) duration = 0;
-		if(reverse) {
-			$(e, t).animate({opacity: 1}, duration);
-		} else {
-			$(e, t).animate({opacity: 0}, duration);
+    return {
+		trigger: trig,
+		play: function(t, reverse, skip) {
+			duration = d;
+			if(skip) duration = 0;
+			this.disappearance = function() {
+				if(reverse) {
+					$(e, t).animate({opacity: 1}, duration);
+				} else {
+					$(e, t).animate({opacity: 0}, duration);
+				}
+			};
+			callUsingTrigger(this.disappearance, this.trigger, previousElt, nextElt, nextTrigger, t, reverse);
 		}
-    }
+	};
 }
 
 /*
@@ -167,23 +221,32 @@ Animator.Disappear = function(e, d) {
     trX  the X translation
 	trY  the Y translation
     d   duration
+	previousElt   the id of the previous Elt
+	nextElt   the id of the next Elt
+	trig   the stirng representing the trigger of the event
     */
-Animator.Move = function(e,trX,trY,d) {
+Animator.Move = function(e,trX,trY,d,previousElt, nextElt, nextTrigger, trig) {
     d = d || 0;
-    return function(t, reverse, skip) {
-		duration = d;
-		if(skip) duration = 0;
-		// You have to wait for the animation to be finished to avoid using the wrong starting coordinates
-		$(e).promise().done(function(){
-			currentX = parseInt($(e).css("left"));
-			currentY = parseInt($(e).css("top"));
-			if(reverse) {
-				$(e).animate({left: currentX-trX, top: currentY-trY}, duration);
-			} else {
-				$(e).animate({left: currentX+trX, top: currentY+trY}, duration);
+    return {
+		trigger: trig,
+		play: function(t, reverse, skip) {
+			duration = d;
+			if(skip) duration = 0;
+			// You have to wait for the animation to be finished to avoid using the wrong starting coordinates
+			this.translation = function() {
+				$(e, t).promise().done(function(){
+					currentX = parseInt($(e).css("left"));
+					currentY = parseInt($(e).css("top"));
+					if(reverse) {
+						$(e, t).animate({left: currentX-trX, top: currentY-trY}, duration);
+					} else {
+						$(e, t).animate({left: currentX+trX, top: currentY+trY}, duration);
+					}
+				});
 			}
-		});
-    }
+			callUsingTrigger(this.translation, this.trigger, previousElt, nextElt, nextTrigger, t, reverse);
+		}
+	};
 }
 
 

--- a/extensions/animator/animator.js
+++ b/extensions/animator/animator.js
@@ -51,7 +51,20 @@ function Animator(target, animations) {
         */
     this.restart = function() {
         init();
+		this.next();
     }
+	
+	/*
+		Start animator from the last state.
+		*/
+	this.startFromTheEnd = function() {
+		init();
+		animations.forEach( function(a){
+			console.log("skipping");
+            a(target, false, true);
+			cursor++;
+        });
+	}
 	
 	this.getCursor = function() {
 		return cursor;
@@ -63,7 +76,7 @@ function Animator(target, animations) {
     this.next = function() {
         if( cursor < anims.length ) {
             anim = animations[cursor++];
-            anim(target, false);
+            anim(target, false, false);
             $(document).trigger(events.progress, {'target':target, 'index':cursor-1});
         } else {
             $(document).trigger(events.completed, {'target':target});
@@ -76,7 +89,7 @@ function Animator(target, animations) {
 	this.prev = function() {
 		if( cursor > 0 ) {
 			anim = animations[--cursor];
-			anim(target, true);
+			anim(target, true, false);
 			$(document).trigger(events.progress, {'target':target, 'index':cursor-1});
         } else {
             $(document).trigger(events.completed, {'target':target});
@@ -98,16 +111,11 @@ function Animator(target, animations) {
     }
     
     function init() {           
-		console.log("Animator.init");
         $(document).trigger(events.beforeInitialize, {'target':target});
         
         cursor = 0;
-		console.log("anims.length = " + anims.length)
         if( anims.length>0 ) {
-			console.log("anim Start");
-            anim = animations[cursor++];
-            anim(target, false);
-            
+			anim = animations[cursor];
             $(document).trigger(events.initialize, {'target':target});   
         } else {
             throw "Animator requires at least one animation."
@@ -123,11 +131,13 @@ function Animator(target, animations) {
     */
 Animator.Appear = function(e, d) {
     d = d || 0;
-    return function(t, reverse) {
+    return function(t, reverse, skip) {
+		duration = d
+		if(skip) duration = 0;
 		if(reverse) {
-			$(e, t).animate({opacity: 0}, d);
+			$(e, t).animate({opacity: 0}, duration);
 		} else {
-			$(e, t).animate({opacity: 1}, d);
+			$(e, t).animate({opacity: 1}, duration);
 		}
     }
 }
@@ -140,33 +150,38 @@ Animator.Appear = function(e, d) {
     */
 Animator.Disappear = function(e, d) {
     d = d || 0;
-    return function(t, reverse) {
+    return function(t, reverse, skip) {
+		duration = d
+		if(skip) duration = 0;
 		if(reverse) {
-			$(e, t).animate({opacity: 1}, d);
+			$(e, t).animate({opacity: 1}, duration);
 		} else {
-			$(e, t).animate({opacity: 0}, d);
+			$(e, t).animate({opacity: 0}, duration);
 		}
     }
 }
 
 /*
-    Animator.Transform(e,tr,d)
+    Animator.Move(e,tr,d)
 
     e   element
-    tr  the transformation
+    trX  the X translation
+	trY  the Y translation
     d   duration
     */
 Animator.Move = function(e,trX,trY,d) {
     d = d || 0;
-    return function(t, reverse) {
+    return function(t, reverse, skip) {
+		duration = d
+		if(skip) duration = 0;
 		// You have to wait for the animation to be finished to avoid using the wrong starting coordinates
-		$(e, t).promise().done(function(){
+		$(e).promise().done(function(){
 			currentX = parseInt($(e).css("left"));
 			currentY = parseInt($(e).css("top"));
 			if(reverse) {
-				$(e, t).animate({left: currentX-trX, top: currentY-trY}, d);
+				$(e).animate({left: currentX-trX, top: currentY-trY}, duration);
 			} else {
-				$(e, t).animate({left: currentX+trX, top: currentY+trY}, d);
+				$(e).animate({left: currentX+trX, top: currentY+trY}, duration);
 			}
 		});
     }

--- a/extensions/animator/animator.js
+++ b/extensions/animator/animator.js
@@ -1,0 +1,154 @@
+/* 
+ * To change this template, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+function Animator(target, animations) {
+    
+    var anims,  // list of all animations
+    cursor,     // pointer to the current animation
+    
+    events = {
+		/*
+		This event fires whenever the current animation is completed.
+                The callback function is passed one parameter, target, equal to 
+                the target on which the animation completed.
+		
+		$(document).bind('deck.animator.completed', function(target) {
+		   alert('The animation of '+target+' has just completed.');
+		});
+		*/
+		completed: 'deck.animator.completed',
+		
+                /*
+		This event fires whenever an animation is performed. The callback
+                function is passed two parameters, target and index, equal to
+                the target on which the animation is performed and the index of
+                the animation i.e between 0 and animation.lenght.
+		*/
+		progress: 'deck.animator.progress',
+                
+		/*
+		This event fires at the beginning of deck.animator initialization.
+		*/
+		beforeInitialize: 'deck.animator.beforeInit',
+		
+		/*
+		This event fires at the end of deck.animator initialization.
+		*/
+		initialize: 'deck.animator.init' 
+	};
+    
+    if( $.isArray(animations) ) {
+        anims = animations;
+        cursor = 0;
+    } else {
+        throw "Animator only takes an array of animation as argument.";
+    }
+    
+    /*
+        Restart animator.
+        */
+    this.restart = function() {
+        init();
+    }
+
+    /*  
+        Move to next animation.
+        */
+    this.next = function() {
+        if( cursor < anims.length ) {
+            anim = animations[cursor++];
+            if( $.isArray(anim) ) {
+                $(anim).each( function() {
+                    this(target);
+                });
+            } else {
+                anim(target);
+            }
+            $(document).trigger(events.progress, {'target':target, 'index':cursor-1});
+        } else {
+            $(document).trigger(events.completed, {'target':target});
+        }
+    }
+   
+    /*  
+        Return true if animation is complete.
+        */
+    this.isCompleted = function() {
+        return cursor == anims.length;
+    }
+    
+    /*
+        Push new animation into the animator.
+        */
+    this.push = function(anim) {
+        this.anims.push(anim);
+    }
+    
+    function init() {           
+		console.log("Animator.init");
+        $(document).trigger(events.beforeInitialize, {'target':target});
+        
+        cursor = 0;
+        if( anims.length>0 ) {
+            anim = animations[cursor++];
+            if( $.isArray(anim) ) {
+                $(anim).each( function() {
+                    this(target);
+                });
+            } else {
+                anim(target);
+            }
+            
+            $(document).trigger(events.initialize, {'target':target});   
+        } else {
+            throw "Animator requires at least one animation."
+        }
+    }
+}
+
+/*
+    Animator.Appear(e,d)
+
+    e   element
+    d   duration
+    */
+Animator.Appear = function(e, d) {
+    d = d || 0;
+    return function() {
+		$(e).animate({opacity: 1}, d);
+    }
+}
+
+/*
+    Animator.Disappear(e,d)
+
+    e   element
+    d   duration
+    */
+Animator.Disappear = function(e, d) {
+    d = d || 0;
+    return function() {
+		$(e).animate({opacity: 0}, d);
+    }
+}
+
+/*
+    Animator.Transform(e,tr,d)
+
+    e   element
+    tr  the transformation
+    d   duration
+    */
+Animator.Transform = function(e,tr,d) {
+    d = d || 0;
+    return function(t) {
+        var $svg = $(t).svg('get');
+        $(e, $svg.root()).each( function(){
+            $(this).animate({'svgTransform': tr}, d);
+        })
+    }
+}
+
+

--- a/extensions/animator/animator.js
+++ b/extensions/animator/animator.js
@@ -1,3 +1,19 @@
+/**
+ * This class acts as a state machine to play and keep track of an ongoing 
+ * list of animations.
+ *
+ * The following vocabulary is used in the documentation: 
+ *   - action/animation: A animation unit, such as "move" or "appear",
+ *       applied to a single HTML element. More specifically, an animation is
+ *       an object containing an action and the function to play it. 
+ *       An action is a JSON description of an animation.
+ *   - sequence: A list of actions between two actions triggered by "onChange",
+ *       the first one be included but not the last one.
+ *       When next or prev is called, a sequence of actions is played.
+ *   - animator: This class or one of its instances, i.e. what keeps track of 
+ *       what actions will be played next depending on the next method called
+ *       by the user.
+ */
 function Animator(target, animations) {
 
     TriggerEnum = {

--- a/extensions/animator/animator.js
+++ b/extensions/animator/animator.js
@@ -102,7 +102,9 @@ function Animator(target, animations) {
         $(document).trigger(events.beforeInitialize, {'target':target});
         
         cursor = 0;
+		console.log("anims.length = " + anims.length)
         if( anims.length>0 ) {
+			console.log("anim Start");
             anim = animations[cursor++];
             anim(target, false);
             
@@ -157,13 +159,16 @@ Animator.Disappear = function(e, d) {
 Animator.Move = function(e,trX,trY,d) {
     d = d || 0;
     return function(t, reverse) {
-		currentX = parseInt($(e).css("left"));
-		currentY = parseInt($(e).css("top"));
-		if(reverse) {
-			$(e, t).animate({left: currentX-trX, top: currentY-trY}, d);
-		} else {
-			$(e, t).animate({left: currentX+trX, top: currentY+trY}, d);
-		}
+		// You have to wait for the animation to be finished to avoid using the wrong starting coordinates
+		$(e, t).promise().done(function(){
+			currentX = parseInt($(e).css("left"));
+			currentY = parseInt($(e).css("top"));
+			if(reverse) {
+				$(e, t).animate({left: currentX-trX, top: currentY-trY}, d);
+			} else {
+				$(e, t).animate({left: currentX+trX, top: currentY+trY}, d);
+			}
+		});
     }
 }
 

--- a/extensions/animator/animator.js
+++ b/extensions/animator/animator.js
@@ -60,7 +60,6 @@ function Animator(target, animations) {
 	this.startFromTheEnd = function() {
 		init();
 		animations.forEach( function(a){
-			console.log("skipping");
             a(target, false, true);
 			cursor++;
         });
@@ -132,7 +131,7 @@ function Animator(target, animations) {
 Animator.Appear = function(e, d) {
     d = d || 0;
     return function(t, reverse, skip) {
-		duration = d
+		duration = d;
 		if(skip) duration = 0;
 		if(reverse) {
 			$(e, t).animate({opacity: 0}, duration);
@@ -151,7 +150,7 @@ Animator.Appear = function(e, d) {
 Animator.Disappear = function(e, d) {
     d = d || 0;
     return function(t, reverse, skip) {
-		duration = d
+		duration = d;
 		if(skip) duration = 0;
 		if(reverse) {
 			$(e, t).animate({opacity: 1}, duration);
@@ -172,7 +171,7 @@ Animator.Disappear = function(e, d) {
 Animator.Move = function(e,trX,trY,d) {
     d = d || 0;
     return function(t, reverse, skip) {
-		duration = d
+		duration = d;
 		if(skip) duration = 0;
 		// You have to wait for the animation to be finished to avoid using the wrong starting coordinates
 		$(e).promise().done(function(){

--- a/extensions/animator/animator.js
+++ b/extensions/animator/animator.js
@@ -1,73 +1,75 @@
 function Animator(target, animations) {
 
-	TriggerEnum = {
-		ONCHANGE: "onChange",
-		WITHPREVIOUS: "withPrevious",
-		AFTERPREVIOUS: "afterPrevious"
-	}
+    TriggerEnum = {
+        ONCHANGE: "onChange",
+        WITHPREVIOUS: "withPrevious",
+        AFTERPREVIOUS: "afterPrevious"
+    }
     
     var anims,  // list of all animations
     cursor,     // pointer to the current animation
     
     events = {
-		/*
-		This event fires whenever the current animation is has nothing left to start playing.
-                The callback function is passed two parameters, target, equal to 
-                the target on which the animation completed, and reverse, 
-				true if the animation has been completed in reverse order
-		
-		$(document).bind('deck.animator.completed', function(target, reverse) {
-		   alert('The animation of '+target+' has just completed.');
-		});
-		*/
-		completed: 'deck.animator.completed',
-		
-		/*
-		This event fires whenever a sequence of animations is performed. The callback
-                function is passed three parameters, target, id and reverse, equal to
-                the target on which the animation is performed, the id of
-                the animation, and a boolean equal to true if the animation has been 
-				performed in reverse order
-		*/
-		sequenceStart: 'deck.animator.sequence.start',
-		
-		/*
-		This event fires whenever a sequence of animations has finished performing. The callback
-                function is passed three parameters, target, id and reverse, equal to
-                the target on which the animation is performed, the id of
-                the animation, and a boolean equal to true if the animation has been 
-				performed in reverse order
-		*/
-		sequenceStop: 'deck.animator.sequence.stop',
-		
-		/*
-		This event fires whenever a single action is performed. The callback function
-				is passed three parameters, target, id and reverse, equal to
-                the target on which the animation is performed, the id of
-                the animation, and a boolean equal to true if the animation has been 
-				performed in reverse order
-		*/
-		actionStart: 'deck.animator.action.start',
-		
-		/*
-		This event fires whenever a single action has finished performing. The callback function
-				is passed three parameters, target, id and reverse, equal to
-                the target on which the animation is performed, the id of
-                the animation, and a boolean equal to true if the animation has been 
-				performed in reverse order
-		*/
-		actionStop: 'deck.animator.action.stop',
+        /**
+         * This event fires whenever the current animation is has nothing left 
+         * to start playing.
+         * The callback function is passed two parameters, target, equal to 
+         * the target on which the animation completed, and reverse, 
+         * true if the animation has been completed in reverse order
+         *
+         * example : 
+         * $(document).bind('deck.animator.completed', function(target, reverse) {
+         *   alert('The animation of '+target+' has just completed.');
+         * });
+         */
+        completed: 'deck.animator.completed',
+        
+        /**
+         * This event fires whenever a sequence of animations is performed. 
+         * The callback function is passed three parameters, target, id and reverse, 
+         * equal to the target on which the animation is performed, the id of
+         * the animation, and a boolean equal to true if the animation has been 
+         * performed in reverse order
+         */
+        sequenceStart: 'deck.animator.sequence.start',
+        
+        /**
+         * This event fires whenever a sequence of animations has finished performing. 
+         * The callback function is passed three parameters, target, id and reverse, 
+         * equal to the target on which the animation is performed, the id of
+         * the animation, and a boolean equal to true if the animation has been 
+         * performed in reverse order
+         */
+        sequenceStop: 'deck.animator.sequence.stop',
+        
+        /**
+         * This event fires whenever a single action is performed. 
+         * The callback function is passed three parameters, target, id and reverse, 
+         * equal to the target on which the animation is performed, the id of
+         * the animation, and a boolean equal to true if the animation has been 
+         * performed in reverse order
+         */
+        actionStart: 'deck.animator.action.start',
+        
+        /**
+         * This event fires whenever a single action has finished performing. 
+         * The callback function is passed three parameters, target, id and reverse, 
+         * equal to the target on which the animation is performed, the id of
+         * the animation, and a boolean equal to true if the animation has been 
+         * performed in reverse order
+         */
+        actionStop: 'deck.animator.action.stop',
                 
-		/*
-		This event fires at the beginning of deck.animator initialization.
-		*/
-		beforeInitialize: 'deck.animator.beforeInit',
-		
-		/*
-		This event fires at the end of deck.animator initialization.
-		*/
-		initialize: 'deck.animator.init'
-	};
+        /**
+         * This event fires at the beginning of deck.animator initialization.
+         */
+        beforeInitialize: 'deck.animator.beforeInit',
+        
+        /**
+         * This event fires at the end of deck.animator initialization.
+         */
+        initialize: 'deck.animator.init'
+    };
     
     if( $.isArray(animations) ) {
         anims = animations;
@@ -76,177 +78,177 @@ function Animator(target, animations) {
         throw "Animator only takes an array of animation as argument.";
     }
     
-    /*
-        Restart animator.
-        */
+    /**
+     * Restart animator.
+     */
     this.restart = function() {
         init();
-		this.next(false);
+        this.next(false);
     }
-	
-	/*
-		Start animator from the last state.
-		*/
-	this.startFromTheEnd = function() {
-		init();
-		animations.forEach( function(a){
+    
+    /**
+     * Start animator from the last state.
+     */
+    this.startFromTheEnd = function() {
+        init();
+        animations.forEach( function(a){
             playAnimation(a, false, true);
-			cursor++;
+            cursor++;
         });
-		$(document).trigger(events.completed, {'target':target, 'reverse':true});
-	}
-	
-	/*
-		Return true if animation has started playing.
-		*/
-	this.hasStarted = function() {
-		return cursor > 0;
-	}
-	
-	/*  
-        Return true if the animation is finished.
-        */
+        $(document).trigger(events.completed, {'target':target, 'reverse':true});
+    }
+    
+    /**
+     * Return true if animation has started playing.
+     */
+    this.hasStarted = function() {
+        return cursor > 0;
+    }
+    
+    /**
+     * Return true if the animation is finished.
+     */
     this.isCompleted = function() {
         return cursor == anims.length && !this.isOngoing();
     }
-	
-	/*
-		Return true if the animation is ongoing
-		*/
-	this.isOngoing = function() {
-		for(var i = 0; i < animations.length; ++i) {
-			if($(animations[i].action.target, target).is(':animated')) {
-				return true;
-			}
-		}
-		return false;
-	}
+    
+    /**
+     * Return true if the animation is ongoing
+     */
+    this.isOngoing = function() {
+        for(var i = 0; i < animations.length; ++i) {
+            if($(animations[i].action.target, target).is(':animated')) {
+                return true;
+            }
+        }
+        return false;
+    }
 
-    /*  
-        Move to the next state (right before an afterPrevious-triggered action and, 
-		by extension by calling playSequence, right before the next onChange-triggered action).
-        */
+    /** 
+     * Move to the next state (right before an afterPrevious-triggered action and, 
+     * by extension by calling playSequence, right before the next onChange-triggered action).
+     */
     this.next = function(verifyOngoing) {
-		// if a sequence of action is ongoing, cut the animation short on key press
-		if(verifyOngoing && this.isOngoing()) {
-			this.finishOngoing();
-			return;
-		}
-		// else, do the actual next stuff
+        // if a sequence of action is ongoing, cut the animation short on key press
+        if(verifyOngoing && this.isOngoing()) {
+            this.finishOngoing();
+            return;
+        }
+        // else, do the actual next stuff
         if( cursor < anims.length ) {
-			var animationSequence = new Array();
-			$(document).trigger(events.sequenceStart, {'target':target, 'id':animations[cursor].action.id, 'reverse':false});
-			do {
-				anim = animations[cursor++];
-				animationSequence.push(anim);
-				
-				if(cursor < anims.length && animations[cursor].action.trigger === TriggerEnum.ONCHANGE) {
-					break;
-				}
-			} while(cursor < anims.length);
-			playSequence(this, animationSequence, false, false);
-			if(cursor === anims.length) {
-				$(document).trigger(events.completed, {'target':target, 'reverse':false});
-			}
+            var animationSequence = new Array();
+            $(document).trigger(events.sequenceStart, {'target':target, 'id':animations[cursor].action.id, 'reverse':false});
+            do {
+                anim = animations[cursor++];
+                animationSequence.push(anim);
+                
+                if(cursor < anims.length && animations[cursor].action.trigger === TriggerEnum.ONCHANGE) {
+                    break;
+                }
+            } while(cursor < anims.length);
+            playSequence(this, animationSequence, false, false);
+            if(cursor === anims.length) {
+                $(document).trigger(events.completed, {'target':target, 'reverse':false});
+            }
         } else {
             $(document).trigger(events.completed, {'target':target, 'reverse':false});
         }
     }
-	
-	/*
-		Move to the previous state (right before the next (from past to future) onChange-triggered action).
-		*/
-	this.prev = function(verifyOngoing) {
-		if( cursor > 0 ) {
-			// if a sequence of action is ongoing, cut the animation short on key press
-			if(verifyOngoing && this.isOngoing()) {
-				this.finishOngoing();
-				return;
-			}
+    
+    /**
+     * Move to the previous state (right before the next (from past to future) onChange-triggered action).
+     */
+    this.prev = function(verifyOngoing) {
+        if( cursor > 0 ) {
+            // if a sequence of action is ongoing, cut the animation short on key press
+            if(verifyOngoing && this.isOngoing()) {
+                this.finishOngoing();
+                return;
+            }
 
-			var animationSequence = new Array();
-			$(document).trigger(events.sequenceStart, {'target':target, 'index':animations[cursor-1].action.id, 'reverse':true});
-			do {
-				anim = animations[--cursor];
-				animationSequence.push(anim);
-				
-				if(cursor > 0 && animations[cursor].action.trigger === TriggerEnum.ONCHANGE) {
-					break;
-				}
-			} while(cursor > 0);
-			if(cursor === 0) {
-				$(document).trigger(events.completed, {'target':target, 'reverse':true});
-			}
-			playSequence(this, animationSequence, true, true);
+            var animationSequence = new Array();
+            $(document).trigger(events.sequenceStart, {'target':target, 'index':animations[cursor-1].action.id, 'reverse':true});
+            do {
+                anim = animations[--cursor];
+                animationSequence.push(anim);
+                
+                if(cursor > 0 && animations[cursor].action.trigger === TriggerEnum.ONCHANGE) {
+                    break;
+                }
+            } while(cursor > 0);
+            if(cursor === 0) {
+                $(document).trigger(events.completed, {'target':target, 'reverse':true});
+            }
+            playSequence(this, animationSequence, true, true);
         } else {
             $(document).trigger(events.completed, {'target':target, 'reverse':true});
         }
-	}
-	
-	/*
-		Finish immediatly all ongoing animations
-		*/
-	this.finishOngoing = function() {
-		animations.forEach(function(a){
-			$(a.action.target, target).finish();
-		});
-	}
-	
-	/*
-		Add a callback to animationSequence[i].
-		*/
-	function queueAnimation(animator, animationSequence, i, reverse, skip) {
-		animationSequence[i].action.nextPlay = function() {
-			$(document).trigger(events.actionStop, {'target':target, 'id':animationSequence[i].action.id, 'reverse':reverse});
-			if(i < animationSequence.length - 1 &&
-					(animationSequence[i].action.trigger === TriggerEnum.ONCHANGE 
-						|| animationSequence[i+1].action.trigger === TriggerEnum.AFTERPREVIOUS)) {
-				playAnimation(animationSequence[i+1], reverse, skip);
-				for(j = i+2; j < animationSequence.length ; ++j) {
-					if(animationSequence[j].action.trigger === TriggerEnum.WITHPREVIOUS) {
-						playAnimation(animationSequence[j], reverse, skip);
-					}
-				}
-			}
-			
-			if(!animator.isOngoing()) {
-				$(document).trigger(events.sequenceStop, {'target':target, 'id':animationSequence[i].action.id, 'reverse':reverse});
-			}
-		};
-	}
-	
-	/*
-		Play a single action.
-		*/
-	function playAnimation(animation, reverse, skip) {
-		$(document).trigger(events.actionStart, {'target':target, 'id':animation.action.id, 'reverse':reverse});
-		animation.play(target, reverse, skip);
-	}
-	
-	/*
-		Play a sequence of animation
-		*/
-	function playSequence(animator, animationSequence, reverse, skip) {
-		if(animationSequence.length === 0) return;
-		
-		if(reverse) {
-			animationSequence.forEach(function(a){
-				playAnimation(a, reverse, skip);
-			});
-		} else {
-			for(i = 0; i < animationSequence.length; ++i) {
-				queueAnimation(animator, animationSequence, i, reverse, skip);
-			}
-			playAnimation(animationSequence[0], reverse, skip);
-		}
-	}
+    }
+    
+    /**
+     * Finish immediatly all ongoing animations
+     */
+    this.finishOngoing = function() {
+        animations.forEach(function(a){
+            $(a.action.target, target).finish();
+        });
+    }
+    
+    /**
+     * Add a callback to animationSequence[i].
+     */
+    function queueAnimation(animator, animationSequence, i, reverse, skip) {
+        animationSequence[i].action.nextPlay = function() {
+            $(document).trigger(events.actionStop, {'target':target, 'id':animationSequence[i].action.id, 'reverse':reverse});
+            if(i < animationSequence.length - 1 &&
+                    (animationSequence[i].action.trigger === TriggerEnum.ONCHANGE 
+                        || animationSequence[i+1].action.trigger === TriggerEnum.AFTERPREVIOUS)) {
+                playAnimation(animationSequence[i+1], reverse, skip);
+                for(j = i+2; j < animationSequence.length ; ++j) {
+                    if(animationSequence[j].action.trigger === TriggerEnum.WITHPREVIOUS) {
+                        playAnimation(animationSequence[j], reverse, skip);
+                    }
+                }
+            }
+            
+            if(!animator.isOngoing()) {
+                $(document).trigger(events.sequenceStop, {'target':target, 'id':animationSequence[i].action.id, 'reverse':reverse});
+            }
+        };
+    }
+    
+    /**
+     * Play a single action.
+     */
+    function playAnimation(animation, reverse, skip) {
+        $(document).trigger(events.actionStart, {'target':target, 'id':animation.action.id, 'reverse':reverse});
+        animation.play(target, reverse, skip);
+    }
+    
+    /**
+     * Play a sequence of animation
+     */
+    function playSequence(animator, animationSequence, reverse, skip) {
+        if(animationSequence.length === 0) return;
+        
+        if(reverse) {
+            animationSequence.forEach(function(a){
+                playAnimation(a, reverse, skip);
+            });
+        } else {
+            for(i = 0; i < animationSequence.length; ++i) {
+                queueAnimation(animator, animationSequence, i, reverse, skip);
+            }
+            playAnimation(animationSequence[0], reverse, skip);
+        }
+    }
     
     function init() {           
         $(document).trigger(events.beforeInitialize, {'target':target});
         
         cursor = 0;
         if( anims.length>0 ) {
-			anim = animations[cursor];
+            anim = animations[cursor];
             $(document).trigger(events.initialize, {'target':target}); 
         } else {
             throw "Animator requires at least one animation."
@@ -254,81 +256,81 @@ function Animator(target, animations) {
     }
 }
 
-///////////////////////////////////////////////////////////
-/////                   ANIMATIONS                    /////
-///////////////////////////////////////////////////////////
+/*#########################################################
+#####                   ANIMATIONS                    #####
+#########################################################*/
 
-/*
-    Animator.Appear(prevA, a, nextA)
-
-    a   current action JSON descriptor
-    */
+/**
+ * Animator.Appear(prevA, a, nextA)
+ * 
+ * a   current action JSON descriptor
+ */
 Animator.Appear = function(a) {
-	return generateAnimatedAction(a, function(t, reverse, skip) {
-		playReversibleAnimation(a, t, 
-			{opacity: 1}, {opacity: 0}, 
-			reverse, skip);
-	});
+    return generateAnimatedAction(a, function(t, reverse, skip) {
+        playReversibleAnimation(a, t, 
+            {opacity: 1}, {opacity: 0}, 
+            reverse, skip);
+    });
 }
 
-/*
-    Animator.Disappear(prevA, a, nextA)
-
-    a   current action JSON descriptor
-    */
+/**
+ * Animator.Disappear(prevA, a, nextA)
+ * 
+ * a   current action JSON descriptor
+ */
 Animator.Disappear = function(a) {
-	return generateAnimatedAction(a, function(t, reverse, skip) {
-		playReversibleAnimation(a, t, 
-			{opacity: 0}, {opacity: 1}, 
-			reverse, skip);
-	});
+    return generateAnimatedAction(a, function(t, reverse, skip) {
+        playReversibleAnimation(a, t, 
+            {opacity: 0}, {opacity: 1}, 
+            reverse, skip);
+    });
 }
 
-/*
-    Animator.Move(prevA, a, nextA)
-
-    a   current action JSON descriptor
-    */
+/**
+ * Animator.Move(prevA, a, nextA)
+ * 
+ * a   current action JSON descriptor
+ */
 Animator.Move = function(a) {
-	return generateAnimatedAction(a, function(t, reverse, skip) {
-		currentX = parseInt($(a.target).css("left"));
-		currentY = parseInt($(a.target).css("top"));
-		trX = parseInt(a.trX);
-		trY = parseInt(a.trY);
-		playReversibleAnimation(a, t, 
-			{left: currentX+trX, top: currentY+trY}, 
-			{left: currentX-trX, top: currentY-trY}, 
-			reverse, skip);
-	});
+    return generateAnimatedAction(a, function(t, reverse, skip) {
+        currentX = parseInt($(a.target).css("left"));
+        currentY = parseInt($(a.target).css("top"));
+        trX = parseInt(a.trX);
+        trY = parseInt(a.trY);
+        playReversibleAnimation(a, t, 
+            {left: currentX+trX, top: currentY+trY}, 
+            {left: currentX-trX, top: currentY-trY}, 
+            reverse, skip);
+    });
 }
 
 
-///////////////////////////////////////////////////////////
-/////                     UTILS                       /////
-///////////////////////////////////////////////////////////
+/*#########################################################
+#####                     UTILS                       #####
+#########################################################*/
 
-/*
-	Animate the target element depending on various playing options.
-	*/
+/**
+ * Animate the target element depending on various playing options.
+ */
 playReversibleAnimation = function(a, t, 
-		cssProperty, reverseCssProperty, 
-		reverse, skip) {
-	d = a.duration;
-	if(d === undefined || skip) d = 0;
-	if(reverse) {
-		$(a.target, t).animate(reverseCssProperty, d);
-	} else {
-		$(a.target, t).animate(cssProperty, d, undefined, a.nextPlay);
-	}
+        cssProperty, reverseCssProperty, 
+        reverse, skip) {
+    d = a.duration;
+    if(d === undefined || skip) d = 0;
+    if(reverse) {
+        $(a.target, t).animate(reverseCssProperty, d);
+    } else {
+        $(a.target, t).animate(cssProperty, d, undefined, a.nextPlay);
+    }
 }
 
-/*
-	Generates an object containing information about the current animation, 
-	how to play it, and information about the next and previous animations.
-	*/
+/**
+ * Generates an object containing information about the current animation, 
+ * how to play it, and information about the next and previous animations.
+ */
 generateAnimatedAction = function(currentA, currentAnimFunc) {
-	return {
-		action: currentA,
-		play: currentAnimFunc
-	};
+    return {
+        action: currentA,
+        play: currentAnimFunc
+    };
 }

--- a/extensions/animator/deck.animator.js
+++ b/extensions/animator/deck.animator.js
@@ -51,11 +51,11 @@ Slides can include elements which then can be animated using the Animator.
 			animations = new Array();
 			for(animInd = 0; animInd < animationsJSON.length; ++animInd) {
 				if(animationsJSON[animInd].type === "move") {
-					animations.push(Animator.Move(animInd, animationsJSON[animInd-1], animationsJSON[animInd], animationsJSON[animInd+1]));
+					animations.push(Animator.Move(animInd, animationsJSON[animInd]));
 				} else if (animationsJSON[animInd].type === 'appear') {
-					animations.push(Animator.Appear(animInd, animationsJSON[animInd-1], animationsJSON[animInd], animationsJSON[animInd+1]));
+					animations.push(Animator.Appear(animInd, animationsJSON[animInd]));
 				} else if (animationsJSON[animInd].type === 'disappear') {
-					animations.push(Animator.Disappear(animInd, animationsJSON[animInd-1], animationsJSON[animInd], animationsJSON[animInd+1]));
+					animations.push(Animator.Disappear(animInd, animationsJSON[animInd]));
 				}
 			}
 			$slide.data('slide-animator', new Animator(animatorJSON.target, animations));
@@ -104,11 +104,11 @@ Slides can include elements which then can be animated using the Animator.
 				if ( !animator.hasStarted() ) {
 					animator.restart();
 				} else {
-					animator.next();
+					animator.next(true);
 				} 
 			} else if ((from === to+1 || (from === to && to === 0)) && animator.hasStarted()) {
 				e.preventDefault();
-				animator.prev();
+				animator.prev(true);
 			}
 		}
 	})

--- a/extensions/animator/deck.animator.js
+++ b/extensions/animator/deck.animator.js
@@ -47,27 +47,14 @@ Slides can include elements which then can be animated using the Animator.
 			if(!animatorJSON) continue;
 			var animationsJSON = animatorJSON.actions;
 			animations = new Array();
-			previousEltId = undefined;
-			nextEltId = undefined;
-			nextEltTrigger = undefined;
 			for(animInd = 0; animInd < animationsJSON.length; ++animInd) {
-				var a = animationsJSON[animInd];
-				var nextA = animationsJSON[animInd+1];
-				if(nextA !== undefined) {
-					nextEltId = nextA.target;
-					nextEltTrigger = nextA.trigger;
-				} else {
-					nextEltId = undefined;
-					nextEltTrigger = undefined;
+				if(animationsJSON[animInd].type === "move") {
+					animations.push(Animator.Move(animationsJSON[animInd-1], animationsJSON[animInd], animationsJSON[animInd+1]));
+				} else if (animationsJSON[animInd].type === 'appear') {
+					animations.push(Animator.Appear(animationsJSON[animInd-1], animationsJSON[animInd], animationsJSON[animInd+1]));
+				} else if (animationsJSON[animInd].type === 'disappear') {
+					animations.push(Animator.Disappear(animationsJSON[animInd-1], animationsJSON[animInd], animationsJSON[animInd+1]));
 				}
-				if(a.type === "move") {
-					animations.push(Animator.Move(a.target, parseInt(a.trX), parseInt(a.trY), parseInt(a.duration), previousEltId, nextEltId, nextEltTrigger, a.trigger));
-				} else if (a.type === 'appear') {
-					animations.push(Animator.Appear(a.target, parseInt(a.duration), previousEltId, nextEltId, nextEltTrigger, a.trigger));
-				} else if (a.type === 'disappear') {
-					animations.push(Animator.Disappear(a.target, parseInt(a.duration), previousEltId, nextEltId, nextEltTrigger, a.trigger));
-				}
-				previousEltId = a.target;
 			}
 			$slide.data('slide-animator', new Animator(animatorJSON.target, animations));
 		}
@@ -112,12 +99,12 @@ Slides can include elements which then can be animated using the Animator.
 		if ( animator !== undefined && pageLoaded) {
 			if( (from === to-1 || (from === to && to === $[deck]('getSlides').length - 1)) && (! animator.isCompleted()) ) {
 				e.preventDefault();
-				if ( animator.getCursor() == 0 ) {
+				if ( !animator.hasStarted() ) {
 					animator.restart();
 				} else {
 					animator.next();
 				} 
-			} else if ((from === to+1 || (from === to && to === 0)) && animator.getCursor() !== 0) {
+			} else if ((from === to+1 || (from === to && to === 0)) && animator.hasStarted()) {
 				e.preventDefault();
 				animator.prev();
 			}

--- a/extensions/animator/deck.animator.js
+++ b/extensions/animator/deck.animator.js
@@ -49,15 +49,20 @@ Slides can include elements which then can be animated using the Animator.
 		 */
 		var animator = eval($slide.data('dahu-animator'));
 		console.log("beforeChange : début");
-		console.log(animator)
-		if ( animator !== undefined && (! animator.isCompleted()) ) {
-			console.log("beforeChange : on ne passe pas !");
-			e.preventDefault();
-			if ( animator.cursor == 0 ) {
-				animator.restart();
-			} else {
-				animator.next();
-			} 
+		if ( animator !== undefined ) {
+			if( from < to && (! animator.isCompleted()) ) {
+				console.log("beforeChange : on ne passe pas !");
+				e.preventDefault();
+				if ( animator.getCursor() == 0 ) {
+					animator.restart();
+				} else {
+					animator.next();
+				} 
+			} else if (from > to && animator.getCursor() !== 0) {
+				console.log("go back from cursor " + animator.getCursor());
+				e.preventDefault();
+				animator.prev();
+			}
 		}
 		console.log("beforeChange : fin");
 	});

--- a/extensions/animator/deck.animator.js
+++ b/extensions/animator/deck.animator.js
@@ -73,15 +73,29 @@ https://github.com/imakewebthings/deck.js/blob/master/GPL-license.txt
         }
     });
     
-    $[deck]('extend', 'autoplayNext', function(e) {
+    /**
+     * Automatically plays the next step of the presentation
+     */
+    function autoplayNext(e) {
         var currentIndex = $[deck]('getCurrentSlideIndex');
         var animator = $[deck]('getAnimator', currentIndex);
-        manageAnimations(e, currentIndex, currentIndex+1);
-        if(animator !== undefined && animator.isCompleted()) {
+        if(animator === undefined || animator.isCompleted()) {
             $[deck]('next');
-            manageAnimations(e, currentIndex+1, currentIndex+2);
+            if($[deck]('getSlides').length > currentIndex+1) {
+                $[deck]('getSlide', currentIndex+1).delay(2000).queue(function(next){
+                    $[deck]('next');
+                    var newCurrentIndex = $[deck]('getCurrentSlideIndex');
+                    manageAnimations(e, newCurrentIndex, newCurrentIndex+1);
+                });
+            }
+        } else {
+            manageAnimations(e, currentIndex, currentIndex+1);
+            if(animator !== undefined && animator.isCompleted()) {
+                $[deck]('next');
+                manageAnimations(e, currentIndex+1, currentIndex+2);
+            }
         }
-    });
+    }
     
     /**
      * Call animation functions when necessary.
@@ -130,7 +144,7 @@ https://github.com/imakewebthings/deck.js/blob/master/GPL-license.txt
             if(e.which === keys.autoplay) {
                 if(!autoplayEnabled) {
                     autoplayEnabled = true;
-                    $[deck]('autoplayNext');
+                    autoplayNext();
                 } else {
                     autoplayEnabled = false;
                 }
@@ -171,7 +185,7 @@ https://github.com/imakewebthings/deck.js/blob/master/GPL-license.txt
     })
     .bind('deck.animator.sequence.stop', function(e, options) {
         if(autoplayEnabled) {
-            $[deck]('autoplayNext', e);
+            autoplayNext(e);
         }
     });
     

--- a/extensions/animator/deck.animator.js
+++ b/extensions/animator/deck.animator.js
@@ -6,172 +6,174 @@ https://github.com/imakewebthings/deck.js/blob/master/MIT-license.txt
 https://github.com/imakewebthings/deck.js/blob/master/GPL-license.txt
 */
 
-/*
-This module provides a support for animated elements to the deck so as to create 
-animation like in most presentation solution e.g powerpoint, keynote, etc.
-Slides can include elements which then can be animated using the Animator.
-*/
+/**
+ * This module provides a support for animated elements to the deck so as to create 
+ * animation like in most presentation solution e.g powerpoint, keynote, etc.
+ * Slides can include elements which then can be animated using the Animator.
+ */
 
 (function($, deck, undefined) {
     var $d = $(document);
-	// determine whether a actual change in slide number has occured before the next action
-	slideChangeHappened = false;
-	// determine whether the animators have finished initializing
-	pageLoaded = false;
-	// determine whether the slides play automtically
-	autoplayEnabled = false;
-	
+
+    // determine whether a actual change in slide number has occured before the next action
+    slideChangeHappened = false;
+    // determine whether the animators have finished initializing
+    pageLoaded = false;
+    // determine whether the slides play automtically
+    autoplayEnabled = false;
+    
     $.extend(true, $[deck].defaults, {
         keys: {
             autoplay: 65 // a
         }
     });
-	
-	$[deck]('extend', 'getCurrentSlideIndex', function() {
-		var current = $[deck]('getSlide');
-		var i = 0;
-		for (; i < $[deck]('getSlides').length; i++) {
-			if ($[deck]('getSlides')[i] == current) return i;
-		}
-		return -1;
+    
+    /**
+     * Gets the index of the current slide
+     */
+    $[deck]('extend', 'getCurrentSlideIndex', function() {
+        var current = $[deck]('getSlide');
+        var i = 0;
+        for (; i < $[deck]('getSlides').length; i++) {
+            if ($[deck]('getSlides')[i] == current) return i;
+        }
+        return -1;
     });
-	
-	/*
-		Returns the animator of the slide.
-		*/
-	$[deck]('extend', 'getAnimator', function(slideNum) {
-		var $slide = $[deck]('getSlide', slideNum);
-		if(!$slide) return undefined;
-		return $slide.data('slide-animator');
-	});
-	
-	/*
-		Init all animators.
-		*/
-	$[deck]('extend', 'initAnimators', function() {
-		for(slideNb = 0; slideNb < $[deck]('getSlides').length; ++slideNb) {
-			var $slide = $[deck]('getSlide', slideNb);
-			var animatorJSON = eval($slide.data('dahu-animator'));
-			
-			if(!animatorJSON) continue;
-			var animationsJSON = animatorJSON.actions;
-			animations = new Array();
-			for(animInd = 0; animInd < animationsJSON.length; ++animInd) {
-				if(animationsJSON[animInd].type === "move") {
-					animations.push(Animator.Move(animationsJSON[animInd]));
-				} else if (animationsJSON[animInd].type === 'appear') {
-					animations.push(Animator.Appear(animationsJSON[animInd]));
-				} else if (animationsJSON[animInd].type === 'disappear') {
-					animations.push(Animator.Disappear(animationsJSON[animInd]));
-				}
-			}
-			$slide.data('slide-animator', new Animator(animatorJSON.target, animations));
-		}
-	});
-	
-	$[deck]('extend', 'autoplayNext', function(e) {
-		var currentIndex = $[deck]('getCurrentSlideIndex');
-		var animator = $[deck]('getAnimator', currentIndex);
-		manageAnimations(e, currentIndex, currentIndex+1);
-		if(animator !== undefined && animator.isCompleted()) {
-			$[deck]('next');
-			manageAnimations(e, currentIndex+1, currentIndex+2);
-		}
-	});
-	
-	/*
-		Call animation functions when necessary.
-		*/
-	function manageAnimations(e, from, to) {
-		slideChangeHappened = false;
+    
+    /**
+     * Returns the animator of the slide.
+     */
+    $[deck]('extend', 'getAnimator', function(slideNum) {
+        var $slide = $[deck]('getSlide', slideNum);
+        if(!$slide) return undefined;
+        return $slide.data('slide-animator');
+    });
+    
+    /**
+     * Init all animators.
+     */
+    $[deck]('extend', 'initAnimators', function() {
+        for(slideNb = 0; slideNb < $[deck]('getSlides').length; ++slideNb) {
+            var $slide = $[deck]('getSlide', slideNb);
+            var animatorJSON = eval($slide.data('dahu-animator'));
+            
+            if(!animatorJSON) continue;
+            var animationsJSON = animatorJSON.actions;
+            animations = new Array();
+            for(animInd = 0; animInd < animationsJSON.length; ++animInd) {
+                if(animationsJSON[animInd].type === "move") {
+                    animations.push(Animator.Move(animationsJSON[animInd]));
+                } else if (animationsJSON[animInd].type === 'appear') {
+                    animations.push(Animator.Appear(animationsJSON[animInd]));
+                } else if (animationsJSON[animInd].type === 'disappear') {
+                    animations.push(Animator.Disappear(animationsJSON[animInd]));
+                }
+            }
+            $slide.data('slide-animator', new Animator(animatorJSON.target, animations));
+        }
+    });
+    
+    $[deck]('extend', 'autoplayNext', function(e) {
+        var currentIndex = $[deck]('getCurrentSlideIndex');
+        var animator = $[deck]('getAnimator', currentIndex);
+        manageAnimations(e, currentIndex, currentIndex+1);
+        if(animator !== undefined && animator.isCompleted()) {
+            $[deck]('next');
+            manageAnimations(e, currentIndex+1, currentIndex+2);
+        }
+    });
+    
+    /**
+     * Call animation functions when necessary.
+     */
+    function manageAnimations(e, from, to) {
+        slideChangeHappened = false;
 
-		/*
-		 * If the animations of the current slide are not complete,
-		 * we keep on doing them and we don't go to the next slide.
-		 */
-		var animator = $[deck]('getAnimator', from);
-		if ( animator !== undefined && pageLoaded) {
-			// ->
-			if( (from === to-1 || (from === to && to === $[deck]('getSlides').length - 1)) && (! animator.isCompleted()) ) {
-				// the function has been called from beforeChange
-				if(e !== undefined) {
-					e.preventDefault();
-				}
-				if ( !animator.hasStarted() ) {
-					animator.restart();
-				} else {
-					animator.next(true);
-				} 
-			// <-
-			} else if ((from === to+1 || (from === to && to === 0)) && animator.hasStarted()) {
-				if(e !== undefined) {
-					e.preventDefault();
-				}
-				animator.prev(true);
-			}
-		}
-	}
-	   
-    /*
-        jQuery.deck('Init')
-        */
+        // If the animations of the current slide are not complete,
+        // we keep on doing them and we don't go to the next slide.
+        var animator = $[deck]('getAnimator', from);
+        if ( animator !== undefined && pageLoaded) {
+            // ->
+            if( (from === to-1 || (from === to && to === $[deck]('getSlides').length - 1)) && (! animator.isCompleted()) ) {
+                // the function has been called from beforeChange
+                if(e !== undefined) {
+                    e.preventDefault();
+                }
+                if ( !animator.hasStarted() ) {
+                    animator.restart();
+                } else {
+                    animator.next(true);
+                } 
+            // <-
+            } else if ((from === to+1 || (from === to && to === 0)) && animator.hasStarted()) {
+                if(e !== undefined) {
+                    e.preventDefault();
+                }
+                animator.prev(true);
+            }
+        }
+    }
+       
+    /**
+     * jQuery.deck('Init')
+     */
     $d.bind('deck.init', function() {
         var keys = $[deck].defaults.keys;
-		
-		// init all animators
-		$[deck]('initAnimators');
-		
-        /* Bind key events */
+        
+        // init all animators
+        $[deck]('initAnimators');
+        
+        // Bind key events
         $d.unbind('keydown.deckanimator').bind('keydown.deckanimator', function(e) {
-			var currentIndex = $[deck]('getCurrentSlideIndex');
-			var nbSlides = $[deck]('getSlides').length;
-			if(e.which === keys.autoplay) {
-				if(!autoplayEnabled) {
-					autoplayEnabled = true;
-					$[deck]('autoplayNext');
-				} else {
-					autoplayEnabled = false;
-				}
-			} else {
-				if (currentIndex === nbSlides -1 && !slideChangeHappened && (e.which === keys.next || $.inArray(e.which, keys.next) > -1)) {
-					autoplayEnabled = false;
-					manageAnimations(undefined, currentIndex, currentIndex);
-				}
-				if (currentIndex === 0 && !slideChangeHappened && (e.which === keys.previous || $.inArray(e.which, keys.previous) > -1)) {
-					autoplayEnabled = false;
-					manageAnimations(undefined, currentIndex, currentIndex);
-				}
-				slideChangeHappened = false;
-			}
+            var currentIndex = $[deck]('getCurrentSlideIndex');
+            var nbSlides = $[deck]('getSlides').length;
+            if(e.which === keys.autoplay) {
+                if(!autoplayEnabled) {
+                    autoplayEnabled = true;
+                    $[deck]('autoplayNext');
+                } else {
+                    autoplayEnabled = false;
+                }
+            } else {
+                if (currentIndex === nbSlides -1 && !slideChangeHappened && (e.which === keys.next || $.inArray(e.which, keys.next) > -1)) {
+                    autoplayEnabled = false;
+                    manageAnimations(undefined, currentIndex, currentIndex);
+                }
+                if (currentIndex === 0 && !slideChangeHappened && (e.which === keys.previous || $.inArray(e.which, keys.previous) > -1)) {
+                    autoplayEnabled = false;
+                    manageAnimations(undefined, currentIndex, currentIndex);
+                }
+                slideChangeHappened = false;
+            }
         });
-		
-		// if there is no anchor, deck.change won't be triggered and the page has finished loading
-		if(!window.location.hash){
-			pageLoaded = true;
-		}
+        
+        // if there is no anchor, deck.change won't be triggered and the page has finished loading
+        if(!window.location.hash){
+            pageLoaded = true;
+        }
     })
-	.bind('deck.beforeChange', function(e, from, to) {
-		manageAnimations(e, from, to);
-	})
-	.bind('deck.change', function(e, from, to) {
-		slideChangeHappened = true;
-		// when the presentation hasn't been loaded from the first slide,
-		// the previous animations are set to their final states
-		if(!pageLoaded) {
-			for(slideNb = 0; slideNb < to; ++slideNb) {
-				var prevAnimator = $[deck]('getAnimator', slideNb);
-				if(prevAnimator !== undefined) {
-					prevAnimator.startFromTheEnd();
-				}
-			}
-		}
-		pageLoaded = true;
-	})
-	.bind('deck.animator.sequence.stop', function(e, options) {
-		if(autoplayEnabled) {
-			$[deck]('autoplayNext', e);
-		}
-	});
-	
-		
+    .bind('deck.beforeChange', function(e, from, to) {
+        manageAnimations(e, from, to);
+    })
+    .bind('deck.change', function(e, from, to) {
+        slideChangeHappened = true;
+        // when the presentation hasn't been loaded from the first slide,
+        // the previous animations are set to their final states
+        if(!pageLoaded) {
+            for(slideNb = 0; slideNb < to; ++slideNb) {
+                var prevAnimator = $[deck]('getAnimator', slideNb);
+                if(prevAnimator !== undefined) {
+                    prevAnimator.startFromTheEnd();
+                }
+            }
+        }
+        pageLoaded = true;
+    })
+    .bind('deck.animator.sequence.stop', function(e, options) {
+        if(autoplayEnabled) {
+            $[deck]('autoplayNext', e);
+        }
+    });
+    
+        
 })(jQuery, 'deck');

--- a/extensions/animator/deck.animator.js
+++ b/extensions/animator/deck.animator.js
@@ -24,6 +24,11 @@ Slides can include elements which then can be animated using the Animator.
 		}
 		return -1;
     });
+	
+	$[deck]('extend', 'getAnimator', function(slideNum) {
+		var $slide = $[deck]('getSlide', slideNum);
+		return eval($slide.data('dahu-animator'));
+	});
 	   
     /*
         jQuery.deck('Init')
@@ -49,32 +54,33 @@ Slides can include elements which then can be animated using the Animator.
     
 	.bind('deck.beforeChange', function(e, from, to) {
 		hasChanged = false;
-		var $slide = $[deck]('getSlide', from);
+		
 		console.log('from = ' + from)
 		console.log('to = ' + to)
 		/*
 		 * If the animations of the current slide are not complete,
 		 * we keep on doing them and we don't go to the next slide.
 		 */
-		var animator = eval($slide.data('dahu-animator'));
-		console.log("beforeChange : début");
+		var animator = $[deck]('getAnimator', from);
 		if ( animator !== undefined ) {
-			console.log("animator detected");
-			if( (from < to || (from === to && to === $[deck]('getSlides').length - 1)) && (! animator.isCompleted()) ) {
-				console.log("beforeChange : on ne passe pas !");
+			var toAnimator = $[deck]('getAnimator', to);
+			// on the case the animation hasn't yet been initialized
+			// for example, when the presentation hasn't been loaded from the first slide
+			if(from > to && !toAnimator.isCompleted()) {
+				toAnimator.startFromTheEnd();
+			}
+			if( (from === to-1 || (from === to && to === $[deck]('getSlides').length - 1)) && (! animator.isCompleted()) ) {
 				e.preventDefault();
 				if ( animator.getCursor() == 0 ) {
 					animator.restart();
 				} else {
 					animator.next();
 				} 
-			} else if ((from > to || (from === to && to === 0)) && animator.getCursor() !== 0) {
-				console.log("go back from cursor " + animator.getCursor());
+			} else if ((from === to+1 || (from === to && to === 0)) && animator.getCursor() !== 0) {
 				e.preventDefault();
 				animator.prev();
 			}
 		}
-		console.log("beforeChange : fin");
 	})
 	
 	.bind('deck.change', function(e, from, to) {

--- a/extensions/animator/deck.animator.js
+++ b/extensions/animator/deck.animator.js
@@ -18,6 +18,14 @@ Slides can include elements which then can be animated using the Animator.
 	slideChangeHappened = false;
 	// determine whether the animators have finished initializing
 	pageLoaded = false;
+	// determine whether the slides play automtically
+	autoplayEnabled = false;
+	
+    $.extend(true, $[deck].defaults, {
+        keys: {
+            autoplay: 65 // a
+        }
+    });
 	
 	$[deck]('extend', 'getCurrentSlideIndex', function() {
 		var current = $[deck]('getSlide');
@@ -33,6 +41,7 @@ Slides can include elements which then can be animated using the Animator.
 		*/
 	$[deck]('extend', 'getAnimator', function(slideNum) {
 		var $slide = $[deck]('getSlide', slideNum);
+		if(!$slide) return undefined;
 		return $slide.data('slide-animator');
 	});
 	
@@ -60,6 +69,16 @@ Slides can include elements which then can be animated using the Animator.
 		}
 	});
 	
+	$[deck]('extend', 'autoplayNext', function(e) {
+		var currentIndex = $[deck]('getCurrentSlideIndex');
+		var animator = $[deck]('getAnimator', currentIndex);
+		manageAnimations(e, currentIndex, currentIndex+1);
+		if(animator !== undefined && animator.isCompleted()) {
+			$[deck]('next');
+			manageAnimations(e, currentIndex+1, currentIndex+2);
+		}
+	});
+	
 	/*
 		Call animation functions when necessary.
 		*/
@@ -74,7 +93,10 @@ Slides can include elements which then can be animated using the Animator.
 		if ( animator !== undefined && pageLoaded) {
 			// ->
 			if( (from === to-1 || (from === to && to === $[deck]('getSlides').length - 1)) && (! animator.isCompleted()) ) {
-				e.preventDefault();
+				// the function has been called from beforeChange
+				if(e !== undefined) {
+					e.preventDefault();
+				}
 				if ( !animator.hasStarted() ) {
 					animator.restart();
 				} else {
@@ -82,7 +104,9 @@ Slides can include elements which then can be animated using the Animator.
 				} 
 			// <-
 			} else if ((from === to+1 || (from === to && to === 0)) && animator.hasStarted()) {
-				e.preventDefault();
+				if(e !== undefined) {
+					e.preventDefault();
+				}
 				animator.prev(true);
 			}
 		}
@@ -101,13 +125,24 @@ Slides can include elements which then can be animated using the Animator.
         $d.unbind('keydown.deckanimator').bind('keydown.deckanimator', function(e) {
 			var currentIndex = $[deck]('getCurrentSlideIndex');
 			var nbSlides = $[deck]('getSlides').length;
-            if (currentIndex === nbSlides -1 && !slideChangeHappened && (e.which === keys.next || $.inArray(e.which, keys.next) > -1)) {
-                manageAnimations(e, currentIndex, currentIndex);
-            }
-			if (currentIndex === 0 && !slideChangeHappened && (e.which === keys.previous || $.inArray(e.which, keys.previous) > -1)) {
-                manageAnimations(e, currentIndex, currentIndex);
-            }
-			slideChangeHappened = false;
+			if(e.which === keys.autoplay) {
+				if(!autoplayEnabled) {
+					autoplayEnabled = true;
+					$[deck]('autoplayNext');
+				} else {
+					autoplayEnabled = false;
+				}
+			} else {
+				if (currentIndex === nbSlides -1 && !slideChangeHappened && (e.which === keys.next || $.inArray(e.which, keys.next) > -1)) {
+					autoplayEnabled = false;
+					manageAnimations(undefined, currentIndex, currentIndex);
+				}
+				if (currentIndex === 0 && !slideChangeHappened && (e.which === keys.previous || $.inArray(e.which, keys.previous) > -1)) {
+					autoplayEnabled = false;
+					manageAnimations(undefined, currentIndex, currentIndex);
+				}
+				slideChangeHappened = false;
+			}
         });
 		
 		// if there is no anchor, deck.change won't be triggered and the page has finished loading
@@ -118,7 +153,6 @@ Slides can include elements which then can be animated using the Animator.
 	.bind('deck.beforeChange', function(e, from, to) {
 		manageAnimations(e, from, to);
 	})
-	
 	.bind('deck.change', function(e, from, to) {
 		slideChangeHappened = true;
 		// when the presentation hasn't been loaded from the first slide,
@@ -132,6 +166,11 @@ Slides can include elements which then can be animated using the Animator.
 			}
 		}
 		pageLoaded = true;
+	})
+	.bind('deck.animator.sequence.stop', function(e, options) {
+		if(autoplayEnabled) {
+			$[deck]('autoplayNext', e);
+		}
 	});
 	
 		

--- a/extensions/animator/deck.animator.js
+++ b/extensions/animator/deck.animator.js
@@ -1,0 +1,81 @@
+/*!
+Deck JS - deck.animator
+Copyright (c) 2011-2015 Remi BARRAQUAND, Rémy DELANAUX, Maxime PIA
+Dual licensed under the MIT license and GPL license.
+https://github.com/imakewebthings/deck.js/blob/master/MIT-license.txt
+https://github.com/imakewebthings/deck.js/blob/master/GPL-license.txt
+*/
+
+/*
+This module provides a support for animated SVG to the deck so as to create 
+animation like in most presentation solution e.g powerpoint, keynote, etc.
+Slides can include elements which then can be animated using the Animator.
+*/
+
+(function($, deck, undefined) {
+    var $d = $(document);
+       
+    /*
+        jQuery.deck('Init')
+        */
+    $d.bind('deck.init', function() {
+        var opts = $[deck]('getOptions');
+        var container = $[deck]('getContainer');
+
+		/* The animator name is stored in the slide using the data field in the HTML */
+		
+        /* Go through all slides */
+		/*
+        $.each($[deck]('getSlides'), function(i, $el) {
+            var $slide = $[deck]('getSlide',i);
+            
+            if( $slide.has("[class='deckjs-animated-element']").length>0 ) {
+                $slide.data('animator') = $slide.data('dahu-animator');
+            } else {
+				$slide.data('animator') = undefined;
+			}
+        });
+		*/
+		
+		
+    })
+	
+    /* Update current slide number with each change event */
+    .bind('deck.change', function(e, from, to) {
+        var opts = $[deck]('getOptions');
+        var $slideTo = $[deck]('getSlide', to);
+        var $container = $[deck]('getContainer');
+	
+        /* Restart the animator in the slide */
+		console.log("Parcours de l'animator");
+        if( eval($slideTo.data('dahu-animator')) !== undefined ) {
+			console.log("Reset de l'animator");
+            eval($slideTo.data('dahu-animator')).restart();
+        }
+        console.log("Passage à la suivante");
+    })
+    
+	.bind('deck.beforeChange', function(e, from, to) {
+		var $slide = $[deck]('getSlide', from);
+		
+		/*
+		 * If the animations of the current slide are not complete,
+		 * we keep on doing them and we don't go to the next slide.
+		 */
+		var animator = eval($slide.data('dahu-animator'));
+		console.log("beforeChange : début");
+		console.log(animator)
+		if ( animator !== undefined && (! animator.isCompleted()) ) {
+			console.log("beforeChange : on ne passe pas !");
+			e.preventDefault();
+			if ( animator.cursor == 0 ) {
+				animator.restart();
+			} else {
+				animator.next();
+			} 
+		}
+		console.log("beforeChange : fin");
+	});
+	
+		
+})(jQuery, 'deck');

--- a/extensions/animator/deck.animator.js
+++ b/extensions/animator/deck.animator.js
@@ -39,21 +39,6 @@ Slides can include elements which then can be animated using the Animator.
 		
 		
     })
-	
-    /* Update current slide number with each change event */
-    .bind('deck.change', function(e, from, to) {
-        var opts = $[deck]('getOptions');
-        var $slideTo = $[deck]('getSlide', to);
-        var $container = $[deck]('getContainer');
-	
-        /* Restart the animator in the slide */
-		console.log("Parcours de l'animator");
-        if( eval($slideTo.data('dahu-animator')) !== undefined ) {
-			console.log("Reset de l'animator");
-            eval($slideTo.data('dahu-animator')).restart();
-        }
-        console.log("Passage à la suivante");
-    })
     
 	.bind('deck.beforeChange', function(e, from, to) {
 		var $slide = $[deck]('getSlide', from);

--- a/extensions/animator/deck.animator.js
+++ b/extensions/animator/deck.animator.js
@@ -36,19 +36,41 @@ Slides can include elements which then can be animated using the Animator.
 		return $slide.data('slide-animator');
 	});
 	
-	$[deck]('extend', 'convertAnimatorJSON', function(animatorJSON) {
-		var animationsJSON = animatorJSON.actions;
-		animations = new Array();
-		animationsJSON.forEach( function(a){
-			if(a.type === "move") {
-				animations.push(Animator.Move(a.target, parseInt(a.trX), parseInt(a.trY), parseInt(a.duration)));
-			} else if (a.type === 'appear') {
-				animations.push(Animator.Appear(a.target, parseInt(a.duration)));
-			} else if (a.type === 'disappear') {
-				animations.push(Animator.Disappear(a.target, parseInt(a.duration)));
+	/*
+		Init all animators.
+		*/
+	$[deck]('extend', 'initAnimators', function() {
+		for(slideNb = 0; slideNb < $[deck]('getSlides').length; ++slideNb) {
+			var $slide = $[deck]('getSlide', slideNb);
+			var animatorJSON = eval($slide.data('dahu-animator'));
+			
+			if(!animatorJSON) continue;
+			var animationsJSON = animatorJSON.actions;
+			animations = new Array();
+			previousEltId = undefined;
+			nextEltId = undefined;
+			nextEltTrigger = undefined;
+			for(animInd = 0; animInd < animationsJSON.length; ++animInd) {
+				var a = animationsJSON[animInd];
+				var nextA = animationsJSON[animInd+1];
+				if(nextA !== undefined) {
+					nextEltId = nextA.target;
+					nextEltTrigger = nextA.trigger;
+				} else {
+					nextEltId = undefined;
+					nextEltTrigger = undefined;
+				}
+				if(a.type === "move") {
+					animations.push(Animator.Move(a.target, parseInt(a.trX), parseInt(a.trY), parseInt(a.duration), previousEltId, nextEltId, nextEltTrigger, a.trigger));
+				} else if (a.type === 'appear') {
+					animations.push(Animator.Appear(a.target, parseInt(a.duration), previousEltId, nextEltId, nextEltTrigger, a.trigger));
+				} else if (a.type === 'disappear') {
+					animations.push(Animator.Disappear(a.target, parseInt(a.duration), previousEltId, nextEltId, nextEltTrigger, a.trigger));
+				}
+				previousEltId = a.target;
 			}
-		});
-		return new Animator(animatorJSON.target, animations)
+			$slide.data('slide-animator', new Animator(animatorJSON.target, animations));
+		}
 	});
 	   
     /*
@@ -58,15 +80,8 @@ Slides can include elements which then can be animated using the Animator.
         var keys = $[deck].defaults.keys;
 		
 		// init all animators
-		for(slideNb = 0; slideNb < $[deck]('getSlides').length; ++slideNb) {
-			var $slide = $[deck]('getSlide', slideNb);
-			var animatorJSON = eval($slide.data('dahu-animator'));
-			
-			if(!animatorJSON) continue;
-			
-			$slide.data('slide-animator', $[deck]('convertAnimatorJSON', animatorJSON));
-		}
-        
+		$[deck]('initAnimators');
+		
         /* Bind key events */
         $d.unbind('keydown.deckanimator').bind('keydown.deckanimator', function(e) {
 			var currentIndex = $[deck]('getCurrentSlideIndex');
@@ -79,6 +94,11 @@ Slides can include elements which then can be animated using the Animator.
             }
 			hasChanged = false;
         });
+		
+		// if there is no anchor, deck.change isn't trigger and the page is loaded
+		if(!window.location.hash){
+			pageLoaded = true;
+		}
     })
     
 	.bind('deck.beforeChange', function(e, from, to) {
@@ -89,7 +109,7 @@ Slides can include elements which then can be animated using the Animator.
 		 * we keep on doing them and we don't go to the next slide.
 		 */
 		var animator = $[deck]('getAnimator', from);
-		if ( animator !== undefined ) {
+		if ( animator !== undefined && pageLoaded) {
 			if( (from === to-1 || (from === to && to === $[deck]('getSlides').length - 1)) && (! animator.isCompleted()) ) {
 				e.preventDefault();
 				if ( animator.getCursor() == 0 ) {

--- a/extensions/animator/deck.animator.js
+++ b/extensions/animator/deck.animator.js
@@ -12,6 +12,8 @@ animation like in most presentation solution e.g powerpoint, keynote, etc.
 Slides can include elements which then can be animated using the Animator.
 */
 
+// TODO : refactor
+
 (function($, deck, undefined) {
     var $d = $(document);
 	// determines whether a actuel change in slide number has occured before the next action
@@ -49,11 +51,11 @@ Slides can include elements which then can be animated using the Animator.
 			animations = new Array();
 			for(animInd = 0; animInd < animationsJSON.length; ++animInd) {
 				if(animationsJSON[animInd].type === "move") {
-					animations.push(Animator.Move(animationsJSON[animInd-1], animationsJSON[animInd], animationsJSON[animInd+1]));
+					animations.push(Animator.Move(animInd, animationsJSON[animInd-1], animationsJSON[animInd], animationsJSON[animInd+1]));
 				} else if (animationsJSON[animInd].type === 'appear') {
-					animations.push(Animator.Appear(animationsJSON[animInd-1], animationsJSON[animInd], animationsJSON[animInd+1]));
+					animations.push(Animator.Appear(animInd, animationsJSON[animInd-1], animationsJSON[animInd], animationsJSON[animInd+1]));
 				} else if (animationsJSON[animInd].type === 'disappear') {
-					animations.push(Animator.Disappear(animationsJSON[animInd-1], animationsJSON[animInd], animationsJSON[animInd+1]));
+					animations.push(Animator.Disappear(animInd, animationsJSON[animInd-1], animationsJSON[animInd], animationsJSON[animInd+1]));
 				}
 			}
 			$slide.data('slide-animator', new Animator(animatorJSON.target, animations));


### PR DESCRIPTION
Contrary to the asvg plugin upon which it is based, the animator plugin can animate HTML elements instead of SVG elements of an object tag.
There are several other functionnalities : 
 - Animations can played in the reverse order and skipped
 - Actions within a sequence can be played when the user presses any deck default action key, when the previous animation in the list has finished playing or at the same time as the previous animation in the list.
 - The presentation can be played automatically.