### PR TITLE
Fix bugs during autoplay or while playing slides with an empty animator

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,23 @@
+{
+  "name": "deck.ext.js",
+  "version": "0.1.0",
+  "homepage": "https://github.com/barraq/deck.ext.js",
+  "authors": [
+    "Remi Barraquand <dev@remibarraquand.com>"
+  ],
+  "description": "Extensions, themes and use cases for Deck.js",
+  "keywords": [
+    "DeckJS",
+    "Themes",
+    "SVG",
+    "Notes"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}

--- a/examples/fulldemo/slides.html
+++ b/examples/fulldemo/slides.html
@@ -79,7 +79,7 @@
 <section class="slide">
     <h2>Section 2</h2>
     <p>If you want to learn about making your own themes, extending deck.js, and more, check out the&nbsp;<a href="../docs/">documentation</a>.</p>
-    <object type="deckjs/asvg" id="canvas_1">
+    <object class="deckjs-asvg-object" id="canvas_1" type="image/svg+xml">
       <param name="src" value="media/circle.svg" />
       <param name="width" value="100%" />
       <param name="height" value="400px" />
@@ -100,14 +100,14 @@
     <h2>Section 3</h2>
     <p>If you want to learn about making your own themes, extending deck.js, and more, check out the&nbsp;<a href="../docs/">documentation</a>.</p>
     <div class="centerbox">
-        <object type="deckjs/asvg" id="canvas_2" class="half">
+        <object class="deckjs-asvg-object half" id="canvas_2" type="image/svg+xml">
           <param name="src" value="media/circle.svg" />
           <param name="width" value="100%" />
           <param name="height" value="400px" />
           <param name="animator" value="c2Anim" />
           <param name="autoStart" value="0" />
         </object>
-        <object type="deckjs/asvg" id="canvas_3" class="half">
+        <object class="deckjs-asvg-object half" id="canvas_3" type="image/svg+xml">
           <param name="src" value="media/circle.svg" />
           <param name="width" value="100%" />
           <param name="height" value="400px" />
@@ -132,7 +132,7 @@
 <section class="slide">
     <h2>Section 3</h2>
     <p>If you want to learn about making your own themes, extending deck.js, and more, check out the&nbsp;<a href="../docs/">documentation</a>.</p>
-    <object type="deckjs/asvg" id="canvas_4">
+    <object class="deckjs-asvg-object" id="canvas_4" type="image/svg+xml">
       <param name="src" value="media/schema_1.svg" />
       <param name="width" value="100%" />
       <param name="height" value="400px" />

--- a/examples/fulldemo/slides.html
+++ b/examples/fulldemo/slides.html
@@ -21,7 +21,7 @@
     <link rel="stylesheet" href="../../../deckjs/extensions/status/deck.status.css">
     <link rel="stylesheet" href="../../../deckjs/extensions/hash/deck.hash.css">
     <link rel="stylesheet" href="../../extensions/toc/deck.toc.css">
-    <link rel="stylesheet" href="../../extensions/asvg/deck.asvg.css">
+    <link rel="stylesheet" href="../../extensions/animator/deck.animator.css">
 
     <!-- Theme CSS files (menu swaps these out) -->
     <link rel="stylesheet" id="style-theme-link" href="../../themes/style/beamer.css">
@@ -37,7 +37,7 @@
     <!-- Jquery SVG -->
     <script type="text/javascript" src="../../libs/jquerysvg/jquery.svg.js"></script>
     <script type="text/javascript" src="../../libs/jquerysvg/jquery.svganim.js"></script>
-    <script type="text/javascript" src="../../extensions/asvg/animator.js"></script>
+    <script type="text/javascript" src="../../extensions/animator/animator.js"></script>
     <script type="text/javascript" src="../../../deckjs/modernizr.custom.js"></script>
     
 </head>
@@ -96,7 +96,7 @@
     </script>
 </section>
     
-<section class="slide">
+<section class="slide" data-dahu-animator="c2Anim" >
     <h2>Section 3</h2>
     <p>If you want to learn about making your own themes, extending deck.js, and more, check out the&nbsp;<a href="../docs/">documentation</a>.</p>
     <div class="centerbox">
@@ -104,19 +104,17 @@
           <param name="src" value="media/circle.svg" />
           <param name="width" value="100%" />
           <param name="height" value="400px" />
-          <param name="animator" value="c2Anim" />
           <param name="autoStart" value="0" />
         </object>
         <object class="deckjs-asvg-object half" id="canvas_3" type="image/svg+xml">
           <param name="src" value="media/circle.svg" />
           <param name="width" value="100%" />
           <param name="height" value="400px" />
-          <param name="animator" value="c3Anim" />
           <param name="autoStart" value="0" />
         </object>
     </div>
     <script type="text/javascript">
-        var c2Anim = new Animator("#canvas_2", [
+        var s6Anim = new Animator(".slide", [
             [Animator.Appear("#circleRed", 0),Animator.Appear("#circleGreen", 0),Animator.Appear("#circleBlue", 0)],
             Animator.Disappear("#circleRed", 0),
             Animator.Disappear("#circleBlue", 0)
@@ -191,7 +189,7 @@
 <script src="../../../deckjs/extensions/navigation/deck.navigation.js"></script>
 <script src="../../../deckjs/extensions/hash/deck.hash.js"></script>
 <script src="../../extensions/toc/deck.toc.js"></script>
-<script src="../../extensions/asvg/deck.asvg.js"></script>
+<script src="../../extensions/animator/deck.animator.js"></script>
 
 <!-- Specific to this page -->
 <script src="slides.js"></script>

--- a/extensions/animator/animator.js
+++ b/extensions/animator/animator.js
@@ -4,9 +4,6 @@ TriggerEnum = {
 	AFTERPREVIOUS: "afterPrevious"
 }
 
-// TODO : autocomplete animations on slide change
-// TODO : immediatly finish currently playing animation on key press
-
 function Animator(target, animations) {
     
     var anims,  // list of all animations
@@ -70,7 +67,7 @@ function Animator(target, animations) {
         */
     this.restart = function() {
         this.init();
-		this.next();
+		this.next(false);
     }
 	
 	/*
@@ -86,6 +83,13 @@ function Animator(target, animations) {
 	}
 	
 	/*
+		Finish a given animation.
+		*/
+	this.finishAnimation = function(action) {
+		$(action.target, target).finish();
+	}
+	
+	/*
 		Return true if animation has started playing.
 		*/
 	this.hasStarted = function() {
@@ -93,16 +97,21 @@ function Animator(target, animations) {
 	}
 	
 	/*  
-        Return true if animation is complete.
+        Return true if the animation is finished.
         */
     this.isCompleted = function() {
-        return cursor == anims.length;
+        return cursor == anims.length && !this.isOngoing();
     }
 	
-	this.isOnGoing = function() {
-		animations.forEach(function(a){
-			if(a.action.playing) return true;
-		});
+	/*
+		Return true if the animation is ongoing
+			*/
+	this.isOngoing = function() {
+		for(i = 0; i < animations.length; ++i) {
+			if($(animations[i].action.target, target).is(':animated')) {
+				return true;
+			}
+		}
 		return false;
 	}
 	
@@ -124,16 +133,33 @@ function Animator(target, animations) {
 			$(document).trigger(events.completedReverse, {'target':target});
 		}
 	}
+	
+	/*
+		Finish all ongoing animations
+		*/
+	this.finishOngoing = function() {
+		var self = this;
+		animations.forEach(function(a){
+			self.finishAnimation(a.action);
+		});
+	}
 
     /*  
         Move to the next state (right before an afterPrevious-triggered action and, 
 		by extension by calling this.play, right before the next onClick-triggered action).
         */
-    this.next = function() {
+    this.next = function(verifyOngoing) {
+		// if a sequence of action is ongoing, cut the animation short on key press
+		if(verifyOngoing && this.isOngoing()) {
+			console.log("ongoing");
+			this.finishOngoing();
+			while(cursor < animations.length && animations[cursor].action.trigger !== TriggerEnum.ONCLICK) {
+				animations[cursor++].play(target, false, true);
+			}
+			return;
+		}
+		// else, do the actual next stuff
         if( cursor < anims.length ) {
-			// if a sequence of action is ongoing, prevent the next action from playing
-			if(animations[cursor].action.trigger === TriggerEnum.ONCLICK && this.isOnGoing()) return;
-			
 			$(document).trigger(events.progress, {'target':target, 'index':cursor});
 			var animationSequence = new Array();
 			do {
@@ -153,10 +179,13 @@ function Animator(target, animations) {
 	/*
 		Move to the previous state (right before the next (from past to future) onClick-triggered action).
 		*/
-	this.prev = function() {
+	this.prev = function(verifyOngoing) {
 		if( cursor > 0 ) {
-			// if an action ongoing, prevent the previous action from playing
-			if(this.isOnGoing()) return;
+			// if a sequence of action is ongoing, cut the animation short on key press
+			if(verifyOngoing && this.isOngoing()) {
+				this.finishOngoing();
+				return;
+			}
 			
 			$(document).trigger(events.progressReverse, {'target':target, 'index':cursor});
 			var animationSequence = new Array();
@@ -202,7 +231,7 @@ function Animator(target, animations) {
 		
 		if(reverse) {
 			if(action.trigger != TriggerEnum.ONCLICK) {
-				this.prev();
+				this.prev(false);
 			}
 		} else {
 			// play the next sequence automatically if the next key (non-withPrevious) action is triggered on afterPrevious
@@ -216,7 +245,7 @@ function Animator(target, animations) {
 				return;
 			}
 			
-			this.next();
+			this.next(false);
 		}
 	}
     
@@ -232,7 +261,7 @@ function Animator(target, animations) {
             $(document).trigger(events.initialize, {'target':target}); 
 			// autostart if necessary
 			if(anim.action.trigger !== TriggerEnum.ONCLICK) {
-				this.next();
+				this.next(false);
 			}
         } else {
             throw "Animator requires at list one animation."
@@ -281,7 +310,7 @@ Animator.Disappear = function(ind, a) {
 Animator.Move = function(ind, a) {
 	return generateChainedAnimation(ind, a, function(t, reverse, skip) {
 		// One needs to wait for the animation to be finished to avoid using the wrong starting coordinates
-		$(a.target, t).promise().done(function(){
+		//$(a.target, t).promise().done(function(){
 			currentX = parseInt($(a.target).css("left"));
 			currentY = parseInt($(a.target).css("top"));
 			trX = parseInt(a.trX);
@@ -290,7 +319,7 @@ Animator.Move = function(ind, a) {
 				{left: currentX+trX, top: currentY+trY}, 
 				{left: currentX-trX, top: currentY-trY}, 
 				reverse, skip);
-		});
+		//});
 	});
 }
 
@@ -305,7 +334,6 @@ Animator.Move = function(ind, a) {
 playRevertibleAnimation = function(a, t, 
 		cssProperty, reverseCssProperty, 
 		reverse, skip) {
-	a.playing = true;
 	d = a.duration;
 	if(d === undefined || skip) d = 0;
 	if(reverse) {
@@ -314,7 +342,6 @@ playRevertibleAnimation = function(a, t,
 		$(a.target, t).animate(cssProperty, d);
 	}
 	$(a.target, t).promise().done(function(){
-		a.playing = false;
 		if(a.trigger !== TriggerEnum.WITHPREVIOUS && !reverse && !skip) {
 			a.animator.continuePlaying(a, reverse);	
 		}

--- a/extensions/animator/animator.js
+++ b/extensions/animator/animator.js
@@ -247,12 +247,11 @@ function Animator(target, animations) {
 /*
     Animator.Appear(prevA, a, nextA)
 
-	prevA   action JSON descriptor preceding the current one
+	ind   index of the action in the corresponding JSON animator array
     a   current action JSON descriptor
-    nextA   action JSON descriptor following the current one
     */
-Animator.Appear = function(ind, prevA, a, nextA) {
-	return generateChainedAnimation(ind, prevA, a, nextA, function(t, reverse, skip) {
+Animator.Appear = function(ind, a) {
+	return generateChainedAnimation(ind, a, function(t, reverse, skip) {
 		playRevertibleAnimation(a, t, 
 			{opacity: 1}, {opacity: 0}, 
 			reverse, skip);
@@ -262,12 +261,11 @@ Animator.Appear = function(ind, prevA, a, nextA) {
 /*
     Animator.Disappear(prevA, a, nextA)
 
-	prevA   action JSON descriptor preceding the current one
+	ind   index of the action in the corresponding JSON animator array
     a   current action JSON descriptor
-    nextA   action JSON descriptor following the current one
     */
-Animator.Disappear = function(ind, prevA, a, nextA) {
-	return generateChainedAnimation(ind, prevA, a, nextA, function(t, reverse, skip) {
+Animator.Disappear = function(ind, a) {
+	return generateChainedAnimation(ind,  a, function(t, reverse, skip) {
 		playRevertibleAnimation(a, t, 
 			{opacity: 0}, {opacity: 1}, 
 			reverse, skip);
@@ -277,12 +275,11 @@ Animator.Disappear = function(ind, prevA, a, nextA) {
 /*
     Animator.Move(prevA, a, nextA)
 
-	prevA   action JSON descriptor preceding the current one
+	ind   index of the action in the corresponding JSON animator array
     a   current action JSON descriptor
-    nextA   action JSON descriptor following the current one
     */
-Animator.Move = function(ind, prevA, a, nextA) {
-	return generateChainedAnimation(ind, prevA, a, nextA, function(t, reverse, skip) {
+Animator.Move = function(ind, a) {
+	return generateChainedAnimation(ind, a, function(t, reverse, skip) {
 		// One needs to wait for the animation to be finished to avoid using the wrong starting coordinates
 		$(a.target, t).promise().done(function(){
 			currentX = parseInt($(a.target).css("left"));
@@ -328,12 +325,10 @@ playRevertibleAnimation = function(a, t,
 	Generates an object containing information about the current animation, 
 	how to play it, and information about the next and previous animations.
 	*/
-generateChainedAnimation = function(ind, prevA, currentA, nextA, currentAnimFunc) {
+generateChainedAnimation = function(ind, currentA, currentAnimFunc) {
 	return {
 		index: ind,
 		action: currentA,
-		prevAction: prevA,
-		nextAction: nextA,
 		play: currentAnimFunc
 	};
 }

--- a/extensions/animator/animator.js
+++ b/extensions/animator/animator.js
@@ -74,7 +74,7 @@ function Animator(target, animations) {
 		Start animator from the last state.
 		*/
 	this.startFromTheEnd = function() {
-		this.init();
+		init();
 		animations.forEach( function(a){
             a.play(target, false, true);
 			cursor++;

--- a/extensions/animator/animator.js
+++ b/extensions/animator/animator.js
@@ -1,0 +1,154 @@
+/* 
+ * To change this template, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+function Animator(target, animations) {
+    
+    var anims,  // list of all animations
+    cursor,     // pointer to the current animation
+    
+    events = {
+		/*
+		This event fires whenever the current animation is completed.
+                The callback function is passed one parameter, target, equal to 
+                the target on which the animation completed.
+		
+		$(document).bind('deck.animator.completed', function(target) {
+		   alert('The animation of '+target+' has just completed.');
+		});
+		*/
+		completed: 'deck.animator.completed',
+		
+                /*
+		This event fires whenever an animation is performed. The callback
+                function is passed two parameters, target and index, equal to
+                the target on which the animation is performed and the index of
+                the animation i.e between 0 and animation.lenght.
+		*/
+		progress: 'deck.animator.progress',
+                
+		/*
+		This event fires at the beginning of deck.animator initialization.
+		*/
+		beforeInitialize: 'deck.animator.beforeInit',
+		
+		/*
+		This event fires at the end of deck.animator initialization.
+		*/
+		initialize: 'deck.animator.init' 
+	};
+    
+    if( $.isArray(animations) ) {
+        anims = animations;
+        cursor = 0;
+    } else {
+        throw "Animator only takes an array of animation as argument.";
+    }
+    
+    /*
+        Restart animator.
+        */
+    this.restart = function() {
+        init();
+    }
+
+    /*  
+        Move to next animation.
+        */
+    this.next = function() {
+        if( cursor < anims.length ) {
+            anim = animations[cursor++];
+            if( $.isArray(anim) ) {
+                $(anim).each( function() {
+                    this(target);
+                });
+            } else {
+                anim(target);
+            }
+            $(document).trigger(events.progress, {'target':target, 'index':cursor-1});
+        } else {
+            $(document).trigger(events.completed, {'target':target});
+        }
+    }
+   
+    /*  
+        Return true if animation is complete.
+        */
+    this.isCompleted = function() {
+        return cursor == anims.length;
+    }
+    
+    /*
+        Push new animation into the animator.
+        */
+    this.push = function(anim) {
+        this.anims.push(anim);
+    }
+    
+    function init() {           
+		console.log("Animator.init");
+        $(document).trigger(events.beforeInitialize, {'target':target});
+        
+        cursor = 0;
+        if( anims.length>0 ) {
+            anim = animations[cursor++];
+            if( $.isArray(anim) ) {
+                $(anim).each( function() {
+                    this(target);
+                });
+            } else {
+                anim(target);
+            }
+            
+            $(document).trigger(events.initialize, {'target':target});   
+        } else {
+            throw "Animator requires at list one animation."
+        }
+    }
+}
+
+/*
+    Animator.Appear(e,d)
+
+    e   element
+    d   duration
+    */
+Animator.Appear = function(e, d) {
+    d = d || 0;
+    return function() {
+		$(e).animate({opacity: 1}, d);
+    }
+}
+
+/*
+    Animator.Disappear(e,d)
+
+    e   element
+    d   duration
+    */
+Animator.Disappear = function(e, d) {
+    d = d || 0;
+    return function() {
+		$(e).animate({opacity: 0}, d);
+    }
+}
+
+/*
+    Animator.Transform(e,tr,d)
+
+    e   element
+    tr  the transformation
+    d   duration
+    */
+Animator.Transform = function(e,tr,d) {
+    d = d || 0;
+    return function(t) {
+        var $svg = $(t).svg('get');
+        $(e, $svg.root()).each( function(){
+            $(this).animate({'svgTransform': tr}, d);
+        })
+    }
+}
+
+

--- a/extensions/animator/animator.js
+++ b/extensions/animator/animator.js
@@ -132,7 +132,7 @@ function Animator(target, animations) {
 Animator.Appear = function(e, d) {
     d = d || 0;
     return function(t, reverse, skip) {
-		duration = d
+		duration = d;
 		if(skip) duration = 0;
 		if(reverse) {
 			$(e, t).animate({opacity: 0}, duration);
@@ -151,7 +151,7 @@ Animator.Appear = function(e, d) {
 Animator.Disappear = function(e, d) {
     d = d || 0;
     return function(t, reverse, skip) {
-		duration = d
+		duration = d;
 		if(skip) duration = 0;
 		if(reverse) {
 			$(e, t).animate({opacity: 1}, duration);
@@ -172,7 +172,7 @@ Animator.Disappear = function(e, d) {
 Animator.Move = function(e,trX,trY,d) {
     d = d || 0;
     return function(t, reverse, skip) {
-		duration = d
+		duration = d;
 		if(skip) duration = 0;
 		// You have to wait for the animation to be finished to avoid using the wrong starting coordinates
 		$(e).promise().done(function(){

--- a/extensions/animator/animator.js
+++ b/extensions/animator/animator.js
@@ -4,6 +4,9 @@ TriggerEnum = {
 	AFTERPREVIOUS: "afterPrevious"
 }
 
+// TODO : autocomplete animations on slide change
+// TODO : immediatly finish currently playing animation on key press
+
 function Animator(target, animations) {
     
     var anims,  // list of all animations
@@ -28,13 +31,21 @@ function Animator(target, animations) {
 		*/
 		completedReverse: 'deck.animator.completedReverse',
 		
-                /*
-		This event fires whenever an animation is performed. The callback
+		/*
+		This event fires whenever a sequence of animations is performed. The callback
                 function is passed two parameters, target and index, equal to
                 the target on which the animation is performed and the index of
                 the animation i.e between 0 and animation.lenght.
 		*/
 		progress: 'deck.animator.progress',
+		
+		/*
+		This event fires whenever a sequence of reverse animations is performed. The callback
+                function is passed two parameters, target and index, equal to
+                the target on which the animation is performed and the index of
+                the animation i.e between 0 and animation.lenght.
+		*/
+		progressReverse: 'deck.animator.progressReverse',
                 
 		/*
 		This event fires at the beginning of deck.animator initialization.
@@ -44,7 +55,7 @@ function Animator(target, animations) {
 		/*
 		This event fires at the end of deck.animator initialization.
 		*/
-		initialize: 'deck.animator.init' 
+		initialize: 'deck.animator.init'
 	};
     
     if( $.isArray(animations) ) {
@@ -58,7 +69,7 @@ function Animator(target, animations) {
         Restart animator.
         */
     this.restart = function() {
-        init();
+        this.init();
 		this.next();
     }
 	
@@ -66,49 +77,92 @@ function Animator(target, animations) {
 		Start animator from the last state.
 		*/
 	this.startFromTheEnd = function() {
-		init();
+		this.init();
 		animations.forEach( function(a){
-			console.log("startFromEnd");
             a.play(target, false, true);
 			cursor++;
         });
 		$(document).trigger(events.completed, {'target':target});
 	}
 	
+	/*
+		Return true if animation has started playing.
+		*/
 	this.hasStarted = function() {
 		return cursor > 0;
 	}
+	
+	/*  
+        Return true if animation is complete.
+        */
+    this.isCompleted = function() {
+        return cursor == anims.length;
+    }
+	
+	this.isOnGoing = function() {
+		animations.forEach(function(a){
+			if(a.action.playing) return true;
+		});
+		return false;
+	}
+	
+	/*
+		Play a sequence of animation.
+		*/
+	this.play = function(animationSequence, isReversed, skip) {
+		if(animationSequence.length === 0) return;
+		var lastPlayed = 0;
+		animationSequence[0].play(target, isReversed, skip);
+		for(i = 1; i < animationSequence.length && (animationSequence[i].action.trigger === TriggerEnum.WITHPREVIOUS || isReversed); ++i) {
+			animationSequence[i].play(target, isReversed, skip);
+			lastPlayed = i;
+		}
+		if(animationSequence[lastPlayed].index === animations.length && !isReversed) {
+			$(document).trigger(events.completed, {'target':target});
+		}
+		if(animationSequence[lastPlayed].index === 0 && isReversed) {
+			$(document).trigger(events.completedReverse, {'target':target});
+		}
+	}
 
     /*  
-        Move to next animation.
+        Move to the next state (right before an afterPrevious-triggered action and, 
+		by extension by calling this.play, right before the next onClick-triggered action).
         */
     this.next = function() {
         if( cursor < anims.length ) {
+			// if a sequence of action is ongoing, prevent the next action from playing
+			if(animations[cursor].action.trigger === TriggerEnum.ONCLICK && this.isOnGoing()) return;
+			
+			$(document).trigger(events.progress, {'target':target, 'index':cursor});
+			var animationSequence = new Array();
 			do {
 				anim = animations[cursor++];
-				anim.play(target, false, false);
-				$(document).trigger(events.progress, {'target':target, 'index':cursor-1});
-				if(cursor < anims.length && animations[cursor].action.trigger === TriggerEnum.ONCLICK) {
+				animationSequence.push(anim);
+				
+				if(cursor < anims.length && animations[cursor].action.trigger !== TriggerEnum.WITHPREVIOUS) {
 					break;
 				}
 			} while(cursor < anims.length);
-            if(cursor === anims.length) {
-				$(document).trigger(events.completed, {'target':target});
-			}
+			this.play(animationSequence, false, false);
         } else {
             $(document).trigger(events.completed, {'target':target});
         }
     }
 	
 	/*
-		Move to previous animation.
+		Move to the previous state (right before the next (from past to future) onClick-triggered action).
 		*/
 	this.prev = function() {
 		if( cursor > 0 ) {
+			// if an action ongoing, prevent the previous action from playing
+			if(this.isOnGoing()) return;
+			
+			$(document).trigger(events.progressReverse, {'target':target, 'index':cursor});
+			var animationSequence = new Array();
 			do {
 				anim = animations[--cursor];
-				anim.play(target, true, false);
-				$(document).trigger(events.progress, {'target':target, 'index':cursor-1});
+				animationSequence.push(anim);
 				
 				if(cursor > 0 && animations[cursor].action.trigger === TriggerEnum.ONCLICK) {
 					break;
@@ -117,17 +171,11 @@ function Animator(target, animations) {
 			if(cursor === 0) {
 				$(document).trigger(events.completedReverse, {'target':target});
 			}
+			this.play(animationSequence, true, true);
         } else {
             $(document).trigger(events.completedReverse, {'target':target});
         }
 	}
-   
-    /*  
-        Return true if animation is complete.
-        */
-    this.isCompleted = function() {
-        return cursor == anims.length;
-    }
     
     /*
         Push new animation into the animator.
@@ -135,14 +183,57 @@ function Animator(target, animations) {
     this.push = function(anim) {
         this.anims.push(anim);
     }
+	
+	/*
+		Continue the current sequence of animations.
+		*/
+	this.continuePlaying = function(action, reverse) {
+		// find the index of the current action in animations
+		curInd = -1;
+		for(i = 0; i < animations.length; ++i) {
+			if(animations[i].action.id === action.id) {
+				curInd = i;
+				break;
+			}
+		}
+		
+		if(curInd === -1) return;
+
+		
+		if(reverse) {
+			if(action.trigger != TriggerEnum.ONCLICK) {
+				this.prev();
+			}
+		} else {
+			// play the next sequence automatically if the next key (non-withPrevious) action is triggered on afterPrevious
+			// find next key animation
+			nextInd = curInd+1;
+			while(nextInd < animations.length && animations[nextInd].action.trigger === TriggerEnum.WITHPREVIOUS) {
+				++nextInd;
+			}
+			// stop if the sequence of automatically playing actions is finished
+			if(nextInd >= animations.length || animations[nextInd].action.trigger === TriggerEnum.ONCLICK) {
+				return;
+			}
+			
+			this.next();
+		}
+	}
     
-    function init() {           
+    this.init = function() {           
         $(document).trigger(events.beforeInitialize, {'target':target});
         
         cursor = 0;
         if( anims.length>0 ) {
+			for(i = 0; i < animations.length; ++i) {
+				animations[i].action.animator = this;
+			}
 			anim = animations[cursor];
-            $(document).trigger(events.initialize, {'target':target});   
+            $(document).trigger(events.initialize, {'target':target}); 
+			// autostart if necessary
+			if(anim.action.trigger !== TriggerEnum.ONCLICK) {
+				this.next();
+			}
         } else {
             throw "Animator requires at list one animation."
         }
@@ -160,14 +251,11 @@ function Animator(target, animations) {
     a   current action JSON descriptor
     nextA   action JSON descriptor following the current one
     */
-Animator.Appear = function(prevA, a, nextA) {
-	return generateChainedAnimation(prevA, a, nextA, function(t, reverse, skip) {
-		this.appearance = function() {
-			playRevertibleAnimation(a.target, t, 
-				{opacity: 1}, {opacity: 0}, 
-				a.duration, reverse, skip);
-		};
-		callUsingTrigger(this.appearance, prevA, a, nextA, t, reverse);
+Animator.Appear = function(ind, prevA, a, nextA) {
+	return generateChainedAnimation(ind, prevA, a, nextA, function(t, reverse, skip) {
+		playRevertibleAnimation(a, t, 
+			{opacity: 1}, {opacity: 0}, 
+			reverse, skip);
 	});
 }
 
@@ -178,14 +266,11 @@ Animator.Appear = function(prevA, a, nextA) {
     a   current action JSON descriptor
     nextA   action JSON descriptor following the current one
     */
-Animator.Disappear = function(prevA, a, nextA) {
-	return generateChainedAnimation(prevA, a, nextA, function(t, reverse, skip) {
-		this.disappearance = function() {
-			playRevertibleAnimation(a.target, t, 
-				{opacity: 0}, {opacity: 1}, 
-				a.duration, reverse, skip);
-		};
-		callUsingTrigger(this.disappearance, prevA, a, nextA, t, reverse);
+Animator.Disappear = function(ind, prevA, a, nextA) {
+	return generateChainedAnimation(ind, prevA, a, nextA, function(t, reverse, skip) {
+		playRevertibleAnimation(a, t, 
+			{opacity: 0}, {opacity: 1}, 
+			reverse, skip);
 	});
 }
 
@@ -196,22 +281,19 @@ Animator.Disappear = function(prevA, a, nextA) {
     a   current action JSON descriptor
     nextA   action JSON descriptor following the current one
     */
-Animator.Move = function(prevA, a, nextA) {
-	return generateChainedAnimation(prevA, a, nextA, function(t, reverse, skip) {
+Animator.Move = function(ind, prevA, a, nextA) {
+	return generateChainedAnimation(ind, prevA, a, nextA, function(t, reverse, skip) {
 		// One needs to wait for the animation to be finished to avoid using the wrong starting coordinates
-		this.translation = function() {
-			$(a.target, t).promise().done(function(){
-				currentX = parseInt($(a.target).css("left"));
-				currentY = parseInt($(a.target).css("top"));
-				trX = parseInt(a.trX);
-				trY = parseInt(a.trY);
-				playRevertibleAnimation(a.target, t, 
-					{left: currentX+trX, top: currentY+trY}, 
-					{left: currentX-trX, top: currentY-trY}, 
-					a.duration, reverse, skip);
-			});
-		}
-		callUsingTrigger(this.translation, prevA, a, nextA, t, reverse);
+		$(a.target, t).promise().done(function(){
+			currentX = parseInt($(a.target).css("left"));
+			currentY = parseInt($(a.target).css("top"));
+			trX = parseInt(a.trX);
+			trY = parseInt(a.trY);
+			playRevertibleAnimation(a, t, 
+				{left: currentX+trX, top: currentY+trY}, 
+				{left: currentX-trX, top: currentY-trY}, 
+				reverse, skip);
+		});
 	});
 }
 
@@ -221,52 +303,34 @@ Animator.Move = function(prevA, a, nextA) {
 ///////////////////////////////////////////////////////////
 
 /*
-    Call the animation function depending on the triggers and playing order.
-    */
-callUsingTrigger = function(func, prevAction, action, nextAction, container, reverse) {
-	if(reverse) {
-		if(nextAction !== undefined && nextAction.trigger === TriggerEnum.AFTERPREVIOUS) {
-			// wait until the previous (reverse) animation is done
-			$(nextAction.target, container).promise().done(function(){
-				func();
-			});
-		} else {
-			func();
-		}
-	} else {
-		if(prevAction !== undefined && action.trigger === TriggerEnum.AFTERPREVIOUS) {
-			// wait until the previous animation is done
-			$(prevAction.target, container).promise().done(function(){
-				func();
-			});
-		} else {
-			func();
-		}
-	}
-}
-
-/*
 	Animate the target element depending on various playing options.
 	*/
-playRevertibleAnimation = function(e, t, 
+playRevertibleAnimation = function(a, t, 
 		cssProperty, reverseCssProperty, 
-		duration, reverse, skip) {
-
-	d = duration;
+		reverse, skip) {
+	a.playing = true;
+	d = a.duration;
 	if(d === undefined || skip) d = 0;
 	if(reverse) {
-		$(e, t).animate(reverseCssProperty, d);
+		$(a.target, t).animate(reverseCssProperty, d);
 	} else {
-		$(e, t).animate(cssProperty, d);
+		$(a.target, t).animate(cssProperty, d);
 	}
+	$(a.target, t).promise().done(function(){
+		a.playing = false;
+		if(a.trigger !== TriggerEnum.WITHPREVIOUS && !reverse && !skip) {
+			a.animator.continuePlaying(a, reverse);	
+		}
+	});
 }
 
 /*
 	Generates an object containing information about the current animation, 
 	how to play it, and information about the next and previous animations.
 	*/
-generateChainedAnimation = function(prevA, currentA, nextA, currentAnimFunc) {
+generateChainedAnimation = function(ind, prevA, currentA, nextA, currentAnimFunc) {
 	return {
+		index: ind,
 		action: currentA,
 		prevAction: prevA,
 		nextAction: nextA,

--- a/extensions/animator/animator.js
+++ b/extensions/animator/animator.js
@@ -52,6 +52,10 @@ function Animator(target, animations) {
     this.restart = function() {
         init();
     }
+	
+	this.getCursor = function() {
+		return cursor;
+	}
 
     /*  
         Move to next animation.

--- a/extensions/animator/animator.js
+++ b/extensions/animator/animator.js
@@ -102,7 +102,9 @@ function Animator(target, animations) {
         $(document).trigger(events.beforeInitialize, {'target':target});
         
         cursor = 0;
+		console.log("anims.length = " + anims.length)
         if( anims.length>0 ) {
+			console.log("anim Start");
             anim = animations[cursor++];
             anim(target, false);
             
@@ -157,13 +159,16 @@ Animator.Disappear = function(e, d) {
 Animator.Move = function(e,trX,trY,d) {
     d = d || 0;
     return function(t, reverse) {
-		currentX = parseInt($(e).css("left"));
-		currentY = parseInt($(e).css("top"));
-		if(reverse) {
-			$(e, t).animate({left: currentX-trX, top: currentY-trY}, d);
-		} else {
-			$(e, t).animate({left: currentX+trX, top: currentY+trY}, d);
-		}
+		// You have to wait for the animation to be finished to avoid using the wrong starting coordinates
+		$(e, t).promise().done(function(){
+			currentX = parseInt($(e).css("left"));
+			currentY = parseInt($(e).css("top"));
+			if(reverse) {
+				$(e, t).animate({left: currentX-trX, top: currentY-trY}, d);
+			} else {
+				$(e, t).animate({left: currentX+trX, top: currentY+trY}, d);
+			}
+		});
     }
 }
 

--- a/extensions/animator/animator.js
+++ b/extensions/animator/animator.js
@@ -60,7 +60,6 @@ function Animator(target, animations) {
 	this.startFromTheEnd = function() {
 		init();
 		animations.forEach( function(a){
-			console.log("skipping");
             a(target, false, true);
 			cursor++;
         });

--- a/extensions/animator/animator.js
+++ b/extensions/animator/animator.js
@@ -59,18 +59,25 @@ function Animator(target, animations) {
     this.next = function() {
         if( cursor < anims.length ) {
             anim = animations[cursor++];
-            if( $.isArray(anim) ) {
-                $(anim).each( function() {
-                    this(target);
-                });
-            } else {
-                anim(target);
-            }
+            anim(target, false);
             $(document).trigger(events.progress, {'target':target, 'index':cursor-1});
         } else {
             $(document).trigger(events.completed, {'target':target});
         }
     }
+	
+	/*
+		Move to previous animation.
+		*/
+	this.prev = function() {
+		if( cursor > 0 ) {
+			anim = animations[--cursor];
+			anim(target, true);
+			$(document).trigger(events.progress, {'target':target, 'index':cursor-1});
+        } else {
+            $(document).trigger(events.completed, {'target':target});
+        }
+	}
    
     /*  
         Return true if animation is complete.
@@ -93,13 +100,7 @@ function Animator(target, animations) {
         cursor = 0;
         if( anims.length>0 ) {
             anim = animations[cursor++];
-            if( $.isArray(anim) ) {
-                $(anim).each( function() {
-                    this(target);
-                });
-            } else {
-                anim(target);
-            }
+            anim(target, false);
             
             $(document).trigger(events.initialize, {'target':target});   
         } else {
@@ -116,8 +117,12 @@ function Animator(target, animations) {
     */
 Animator.Appear = function(e, d) {
     d = d || 0;
-    return function() {
-		$(e).animate({opacity: 1}, d);
+    return function(t, reverse) {
+		if(reverse) {
+			$(e, t).animate({opacity: 0}, d);
+		} else {
+			$(e, t).animate({opacity: 1}, d);
+		}
     }
 }
 
@@ -129,8 +134,12 @@ Animator.Appear = function(e, d) {
     */
 Animator.Disappear = function(e, d) {
     d = d || 0;
-    return function() {
-		$(e).animate({opacity: 0}, d);
+    return function(t, reverse) {
+		if(reverse) {
+			$(e, t).animate({opacity: 1}, d);
+		} else {
+			$(e, t).animate({opacity: 0}, d);
+		}
     }
 }
 
@@ -141,13 +150,16 @@ Animator.Disappear = function(e, d) {
     tr  the transformation
     d   duration
     */
-Animator.Transform = function(e,tr,d) {
+Animator.Move = function(e,trX,trY,d) {
     d = d || 0;
-    return function(t) {
-        var $svg = $(t).svg('get');
-        $(e, $svg.root()).each( function(){
-            $(this).animate({'svgTransform': tr}, d);
-        })
+    return function(t, reverse) {
+		currentX = parseInt($(e).css("left"));
+		currentY = parseInt($(e).css("top"));
+		if(reverse) {
+			$(e, t).animate({left: currentX-trX, top: currentY-trY}, d);
+		} else {
+			$(e, t).animate({left: currentX+trX, top: currentY+trY}, d);
+		}
     }
 }
 

--- a/extensions/animator/animator.js
+++ b/extensions/animator/animator.js
@@ -51,7 +51,20 @@ function Animator(target, animations) {
         */
     this.restart = function() {
         init();
+		this.next();
     }
+	
+	/*
+		Start animator from the last state.
+		*/
+	this.startFromTheEnd = function() {
+		init();
+		animations.forEach( function(a){
+			console.log("skipping");
+            a(target, false, true);
+			cursor++;
+        });
+	}
 	
 	this.getCursor = function() {
 		return cursor;
@@ -63,7 +76,7 @@ function Animator(target, animations) {
     this.next = function() {
         if( cursor < anims.length ) {
             anim = animations[cursor++];
-            anim(target, false);
+            anim(target, false, false);
             $(document).trigger(events.progress, {'target':target, 'index':cursor-1});
         } else {
             $(document).trigger(events.completed, {'target':target});
@@ -76,7 +89,7 @@ function Animator(target, animations) {
 	this.prev = function() {
 		if( cursor > 0 ) {
 			anim = animations[--cursor];
-			anim(target, true);
+			anim(target, true, false);
 			$(document).trigger(events.progress, {'target':target, 'index':cursor-1});
         } else {
             $(document).trigger(events.completed, {'target':target});
@@ -98,16 +111,11 @@ function Animator(target, animations) {
     }
     
     function init() {           
-		console.log("Animator.init");
         $(document).trigger(events.beforeInitialize, {'target':target});
         
         cursor = 0;
-		console.log("anims.length = " + anims.length)
         if( anims.length>0 ) {
-			console.log("anim Start");
-            anim = animations[cursor++];
-            anim(target, false);
-            
+			anim = animations[cursor];
             $(document).trigger(events.initialize, {'target':target});   
         } else {
             throw "Animator requires at list one animation."
@@ -123,11 +131,13 @@ function Animator(target, animations) {
     */
 Animator.Appear = function(e, d) {
     d = d || 0;
-    return function(t, reverse) {
+    return function(t, reverse, skip) {
+		duration = d
+		if(skip) duration = 0;
 		if(reverse) {
-			$(e, t).animate({opacity: 0}, d);
+			$(e, t).animate({opacity: 0}, duration);
 		} else {
-			$(e, t).animate({opacity: 1}, d);
+			$(e, t).animate({opacity: 1}, duration);
 		}
     }
 }
@@ -140,33 +150,38 @@ Animator.Appear = function(e, d) {
     */
 Animator.Disappear = function(e, d) {
     d = d || 0;
-    return function(t, reverse) {
+    return function(t, reverse, skip) {
+		duration = d
+		if(skip) duration = 0;
 		if(reverse) {
-			$(e, t).animate({opacity: 1}, d);
+			$(e, t).animate({opacity: 1}, duration);
 		} else {
-			$(e, t).animate({opacity: 0}, d);
+			$(e, t).animate({opacity: 0}, duration);
 		}
     }
 }
 
 /*
-    Animator.Transform(e,tr,d)
+    Animator.Move(e,tr,d)
 
     e   element
-    tr  the transformation
+    trX  the X translation
+	trY  the Y translation
     d   duration
     */
 Animator.Move = function(e,trX,trY,d) {
     d = d || 0;
-    return function(t, reverse) {
+    return function(t, reverse, skip) {
+		duration = d
+		if(skip) duration = 0;
 		// You have to wait for the animation to be finished to avoid using the wrong starting coordinates
-		$(e, t).promise().done(function(){
+		$(e).promise().done(function(){
 			currentX = parseInt($(e).css("left"));
 			currentY = parseInt($(e).css("top"));
 			if(reverse) {
-				$(e, t).animate({left: currentX-trX, top: currentY-trY}, d);
+				$(e).animate({left: currentX-trX, top: currentY-trY}, duration);
 			} else {
-				$(e, t).animate({left: currentX+trX, top: currentY+trY}, d);
+				$(e).animate({left: currentX+trX, top: currentY+trY}, duration);
 			}
 		});
     }

--- a/extensions/animator/animator.js
+++ b/extensions/animator/animator.js
@@ -1,5 +1,5 @@
 TriggerEnum = {
-	ONCLICK: "onClick",
+	ONCHANGE: "onChange",
 	WITHPREVIOUS: "withPrevious",
 	AFTERPREVIOUS: "afterPrevious"
 }
@@ -115,7 +115,7 @@ function Animator(target, animations) {
 
     /*  
         Move to the next state (right before an afterPrevious-triggered action and, 
-		by extension by calling playSequence, right before the next onClick-triggered action).
+		by extension by calling playSequence, right before the next onChange-triggered action).
         */
     this.next = function(verifyOngoing) {
 		// if a sequence of action is ongoing, cut the animation short on key press
@@ -131,7 +131,7 @@ function Animator(target, animations) {
 				anim = animations[cursor++];
 				animationSequence.push(anim);
 				
-				if(cursor < anims.length && animations[cursor].action.trigger === TriggerEnum.ONCLICK) {
+				if(cursor < anims.length && animations[cursor].action.trigger === TriggerEnum.ONCHANGE) {
 					break;
 				}
 			} while(cursor < anims.length);
@@ -145,7 +145,7 @@ function Animator(target, animations) {
     }
 	
 	/*
-		Move to the previous state (right before the next (from past to future) onClick-triggered action).
+		Move to the previous state (right before the next (from past to future) onChange-triggered action).
 		*/
 	this.prev = function(verifyOngoing) {
 		if( cursor > 0 ) {
@@ -161,7 +161,7 @@ function Animator(target, animations) {
 				anim = animations[--cursor];
 				animationSequence.push(anim);
 				
-				if(cursor > 0 && animations[cursor].action.trigger === TriggerEnum.ONCLICK) {
+				if(cursor > 0 && animations[cursor].action.trigger === TriggerEnum.ONCHANGE) {
 					break;
 				}
 			} while(cursor > 0);

--- a/extensions/animator/deck.animator.js
+++ b/extensions/animator/deck.animator.js
@@ -65,6 +65,9 @@ Slides can include elements which then can be animated using the Animator.
 		}
 	});
 	
+	/*
+		Call animation functions when necessary.
+		*/
 	$[deck]('extend', 'manageAnimations', function(e, from, to) {
 		hasChanged = false;
 
@@ -74,6 +77,7 @@ Slides can include elements which then can be animated using the Animator.
 		 */
 		var animator = $[deck]('getAnimator', from);
 		if ( animator !== undefined && pageLoaded) {
+			// ->
 			if( (from === to-1 || (from === to && to === $[deck]('getSlides').length - 1)) && (! animator.isCompleted()) ) {
 				e.preventDefault();
 				if ( !animator.hasStarted() ) {
@@ -81,6 +85,7 @@ Slides can include elements which then can be animated using the Animator.
 				} else {
 					animator.next(true);
 				} 
+			// <-
 			} else if ((from === to+1 || (from === to && to === 0)) && animator.hasStarted()) {
 				e.preventDefault();
 				animator.prev(true);
@@ -110,7 +115,7 @@ Slides can include elements which then can be animated using the Animator.
 			hasChanged = false;
         });
 		
-		// if there is no anchor, deck.change isn't trigger and the page is loaded
+		// if there is no anchor, deck.change won't be triggered and the page has finished loading
 		if(!window.location.hash){
 			pageLoaded = true;
 		}

--- a/extensions/animator/deck.animator.js
+++ b/extensions/animator/deck.animator.js
@@ -25,9 +25,37 @@ Slides can include elements which then can be animated using the Animator.
 		return -1;
     });
 	
+	/*
+		Returns the animator of the slide.
+		The object is created if it hasn't been done yet.
+		*/
 	$[deck]('extend', 'getAnimator', function(slideNum) {
 		var $slide = $[deck]('getSlide', slideNum);
-		return eval($slide.data('dahu-animator'));
+		
+		if($slide.data('slide-animator'))
+			return $slide.data('slide-animator');
+		
+		var animatorJSON = eval($slide.data('dahu-animator'));
+		
+		if(!animatorJSON)
+			return undefined;
+		
+		var animationsJSON = animatorJSON.actions;
+		animations = new Array();
+		animationsJSON.forEach( function(a){
+			console.log(a.type);
+            if(a.type === "move") {
+				animations.push(Animator.Move(a.target, parseInt(a.trX), parseInt(a.trY), parseInt(a.duration)));
+			} else if (a.type === 'appear') {
+				animations.push(Animator.Appear(a.target, parseInt(a.duration)));
+			} else if (a.type === 'disappear') {
+				animations.push(Animator.Disappear(a.target, parseInt(a.duration)));
+			}
+        });
+		console.log(animations);
+		console.log("target = " + animatorJSON.targetSlide);
+		$slide.data('slide-animator', new Animator(animatorJSON.targetSlide, animations));
+		return $slide.data('slide-animator');
 	});
 	   
     /*
@@ -62,11 +90,12 @@ Slides can include elements which then can be animated using the Animator.
 		 * we keep on doing them and we don't go to the next slide.
 		 */
 		var animator = $[deck]('getAnimator', from);
+		console.log(animator);
 		if ( animator !== undefined ) {
-			var toAnimator = $[deck]('getAnimator', to);
 			// on the case the animation hasn't yet been initialized
 			// for example, when the presentation hasn't been loaded from the first slide
-			if(from > to && !toAnimator.isCompleted()) {
+			var toAnimator = $[deck]('getAnimator', to);
+			if(toAnimator !== undefined && from > to && !toAnimator.isCompleted()) {
 				toAnimator.startFromTheEnd();
 			}
 			if( (from === to-1 || (from === to && to === $[deck]('getSlides').length - 1)) && (! animator.isCompleted()) ) {

--- a/extensions/animator/deck.animator.js
+++ b/extensions/animator/deck.animator.js
@@ -35,6 +35,21 @@ Slides can include elements which then can be animated using the Animator.
 		var $slide = $[deck]('getSlide', slideNum);
 		return $slide.data('slide-animator');
 	});
+	
+	$[deck]('extend', 'convertAnimatorJSON', function(animatorJSON) {
+		var animationsJSON = animatorJSON.actions;
+		animations = new Array();
+		animationsJSON.forEach( function(a){
+			if(a.type === "move") {
+				animations.push(Animator.Move(a.target, parseInt(a.trX), parseInt(a.trY), parseInt(a.duration)));
+			} else if (a.type === 'appear') {
+				animations.push(Animator.Appear(a.target, parseInt(a.duration)));
+			} else if (a.type === 'disappear') {
+				animations.push(Animator.Disappear(a.target, parseInt(a.duration)));
+			}
+		});
+		return new Animator(animatorJSON.targetSlide, animations)
+	});
 	   
     /*
         jQuery.deck('Init')
@@ -49,18 +64,7 @@ Slides can include elements which then can be animated using the Animator.
 			
 			if(!animatorJSON) continue;
 			
-			var animationsJSON = animatorJSON.actions;
-			animations = new Array();
-			animationsJSON.forEach( function(a){
-				if(a.type === "move") {
-					animations.push(Animator.Move(a.target, parseInt(a.trX), parseInt(a.trY), parseInt(a.duration)));
-				} else if (a.type === 'appear') {
-					animations.push(Animator.Appear(a.target, parseInt(a.duration)));
-				} else if (a.type === 'disappear') {
-					animations.push(Animator.Disappear(a.target, parseInt(a.duration)));
-				}
-			});
-			$slide.data('slide-animator', new Animator(animatorJSON.targetSlide, animations));
+			$slide.data('slide-animator', $[deck]('convertAnimatorJSON', animatorJSON));
 		}
         
         /* Bind key events */

--- a/extensions/animator/deck.animator.js
+++ b/extensions/animator/deck.animator.js
@@ -49,8 +49,6 @@ Slides can include elements which then can be animated using the Animator.
 		 */
 		var animator = eval($slide.data('dahu-animator'));
 		console.log("beforeChange : début");
-		console.log(animator);
-		console.log(animator.getCursor());
 		if ( animator !== undefined ) {
 			if( from < to && (! animator.isCompleted()) ) {
 				console.log("beforeChange : on ne passe pas !");

--- a/extensions/animator/deck.animator.js
+++ b/extensions/animator/deck.animator.js
@@ -51,11 +51,11 @@ Slides can include elements which then can be animated using the Animator.
 			animations = new Array();
 			for(animInd = 0; animInd < animationsJSON.length; ++animInd) {
 				if(animationsJSON[animInd].type === "move") {
-					animations.push(Animator.Move(animInd, animationsJSON[animInd]));
+					animations.push(Animator.Move(animationsJSON[animInd]));
 				} else if (animationsJSON[animInd].type === 'appear') {
-					animations.push(Animator.Appear(animInd, animationsJSON[animInd]));
+					animations.push(Animator.Appear(animationsJSON[animInd]));
 				} else if (animationsJSON[animInd].type === 'disappear') {
-					animations.push(Animator.Disappear(animInd, animationsJSON[animInd]));
+					animations.push(Animator.Disappear(animationsJSON[animInd]));
 				}
 			}
 			animationsJSON.forEach( function(a){

--- a/extensions/animator/deck.animator.js
+++ b/extensions/animator/deck.animator.js
@@ -14,7 +14,10 @@ Slides can include elements which then can be animated using the Animator.
 
 (function($, deck, undefined) {
     var $d = $(document);
+	// determines whether a actuel change in slide number has occured before the next action
 	hasChanged = false;
+	// determines whether the animators have finished initializing
+	pageLoaded = false;
 	
 	$[deck]('extend', 'getCurrentSlideIndex', function() {
 		var current = $[deck]('getSlide');
@@ -27,34 +30,9 @@ Slides can include elements which then can be animated using the Animator.
 	
 	/*
 		Returns the animator of the slide.
-		The object is created if it hasn't been done yet.
 		*/
 	$[deck]('extend', 'getAnimator', function(slideNum) {
 		var $slide = $[deck]('getSlide', slideNum);
-		
-		if($slide.data('slide-animator'))
-			return $slide.data('slide-animator');
-		
-		var animatorJSON = eval($slide.data('dahu-animator'));
-		
-		if(!animatorJSON)
-			return undefined;
-		
-		var animationsJSON = animatorJSON.actions;
-		animations = new Array();
-		animationsJSON.forEach( function(a){
-			console.log(a.type);
-            if(a.type === "move") {
-				animations.push(Animator.Move(a.target, parseInt(a.trX), parseInt(a.trY), parseInt(a.duration)));
-			} else if (a.type === 'appear') {
-				animations.push(Animator.Appear(a.target, parseInt(a.duration)));
-			} else if (a.type === 'disappear') {
-				animations.push(Animator.Disappear(a.target, parseInt(a.duration)));
-			}
-        });
-		console.log(animations);
-		console.log("target = " + animatorJSON.targetSlide);
-		$slide.data('slide-animator', new Animator(animatorJSON.targetSlide, animations));
 		return $slide.data('slide-animator');
 	});
 	   
@@ -63,17 +41,36 @@ Slides can include elements which then can be animated using the Animator.
         */
     $d.bind('deck.init', function() {
         var keys = $[deck].defaults.keys;
+		
+		// init all animators
+		for(slideNb = 0; slideNb < $[deck]('getSlides').length; ++slideNb) {
+			var $slide = $[deck]('getSlide', slideNb);
+			var animatorJSON = eval($slide.data('dahu-animator'));
+			
+			if(!animatorJSON) continue;
+			
+			var animationsJSON = animatorJSON.actions;
+			animations = new Array();
+			animationsJSON.forEach( function(a){
+				if(a.type === "move") {
+					animations.push(Animator.Move(a.target, parseInt(a.trX), parseInt(a.trY), parseInt(a.duration)));
+				} else if (a.type === 'appear') {
+					animations.push(Animator.Appear(a.target, parseInt(a.duration)));
+				} else if (a.type === 'disappear') {
+					animations.push(Animator.Disappear(a.target, parseInt(a.duration)));
+				}
+			});
+			$slide.data('slide-animator', new Animator(animatorJSON.targetSlide, animations));
+		}
         
         /* Bind key events */
         $d.unbind('keydown.deckanimator').bind('keydown.deckanimator', function(e) {
 			var currentIndex = $[deck]('getCurrentSlideIndex');
 			var nbSlides = $[deck]('getSlides').length;
             if (currentIndex === nbSlides -1 && !hasChanged && (e.which === keys.next || $.inArray(e.which, keys.next) > -1)) {
-				console.log("next triggered");
                 $d.trigger('deck.beforeChange', [currentIndex, currentIndex]);
             }
 			if (currentIndex === 0 && !hasChanged && (e.which === keys.previous || $.inArray(e.which, keys.previous) > -1)) {
-				console.log("prev triggered");
                 $d.trigger('deck.beforeChange', [currentIndex, currentIndex]);
             }
 			hasChanged = false;
@@ -82,22 +79,13 @@ Slides can include elements which then can be animated using the Animator.
     
 	.bind('deck.beforeChange', function(e, from, to) {
 		hasChanged = false;
-		
-		console.log('from = ' + from)
-		console.log('to = ' + to)
+
 		/*
 		 * If the animations of the current slide are not complete,
 		 * we keep on doing them and we don't go to the next slide.
 		 */
 		var animator = $[deck]('getAnimator', from);
-		console.log(animator);
 		if ( animator !== undefined ) {
-			// on the case the animation hasn't yet been initialized
-			// for example, when the presentation hasn't been loaded from the first slide
-			var toAnimator = $[deck]('getAnimator', to);
-			if(toAnimator !== undefined && from > to && !toAnimator.isCompleted()) {
-				toAnimator.startFromTheEnd();
-			}
 			if( (from === to-1 || (from === to && to === $[deck]('getSlides').length - 1)) && (! animator.isCompleted()) ) {
 				e.preventDefault();
 				if ( animator.getCursor() == 0 ) {
@@ -114,6 +102,17 @@ Slides can include elements which then can be animated using the Animator.
 	
 	.bind('deck.change', function(e, from, to) {
 		hasChanged = true;
+		// when the presentation hasn't been loaded from the first slide,
+		// the previous animations are set to their final states
+		if(!pageLoaded) {
+			for(slideNb = 0; slideNb < to; ++slideNb) {
+				var prevAnimator = $[deck]('getAnimator', slideNb);
+				if(prevAnimator !== undefined) {
+					prevAnimator.startFromTheEnd();
+				}
+			}
+		}
+		pageLoaded = true;
 	});
 	
 		

--- a/extensions/animator/deck.animator.js
+++ b/extensions/animator/deck.animator.js
@@ -16,9 +16,9 @@ Slides can include elements which then can be animated using the Animator.
 
 (function($, deck, undefined) {
     var $d = $(document);
-	// determines whether a actuel change in slide number has occured before the next action
+	// determine whether a actual change in slide number has occured before the next action
 	hasChanged = false;
-	// determines whether the animators have finished initializing
+	// determine whether the animators have finished initializing
 	pageLoaded = false;
 	
 	$[deck]('extend', 'getCurrentSlideIndex', function() {
@@ -64,36 +64,8 @@ Slides can include elements which then can be animated using the Animator.
 			$slide.data('slide-animator', new Animator(animatorJSON.targetSlide, animations));
 		}
 	});
-	   
-    /*
-        jQuery.deck('Init')
-        */
-    $d.bind('deck.init', function() {
-        var keys = $[deck].defaults.keys;
-		
-		// init all animators
-		$[deck]('initAnimators');
-		
-        /* Bind key events */
-        $d.unbind('keydown.deckanimator').bind('keydown.deckanimator', function(e) {
-			var currentIndex = $[deck]('getCurrentSlideIndex');
-			var nbSlides = $[deck]('getSlides').length;
-            if (currentIndex === nbSlides -1 && !hasChanged && (e.which === keys.next || $.inArray(e.which, keys.next) > -1)) {
-                $d.trigger('deck.beforeChange', [currentIndex, currentIndex]);
-            }
-			if (currentIndex === 0 && !hasChanged && (e.which === keys.previous || $.inArray(e.which, keys.previous) > -1)) {
-                $d.trigger('deck.beforeChange', [currentIndex, currentIndex]);
-            }
-			hasChanged = false;
-        });
-		
-		// if there is no anchor, deck.change isn't trigger and the page is loaded
-		if(!window.location.hash){
-			pageLoaded = true;
-		}
-    })
-    
-	.bind('deck.beforeChange', function(e, from, to) {
+	
+	$[deck]('extend', 'manageAnimations', function(e, from, to) {
 		hasChanged = false;
 
 		/*
@@ -114,6 +86,37 @@ Slides can include elements which then can be animated using the Animator.
 				animator.prev(true);
 			}
 		}
+	});
+	   
+    /*
+        jQuery.deck('Init')
+        */
+    $d.bind('deck.init', function() {
+        var keys = $[deck].defaults.keys;
+		
+		// init all animators
+		$[deck]('initAnimators');
+		
+        /* Bind key events */
+        $d.unbind('keydown.deckanimator').bind('keydown.deckanimator', function(e) {
+			var currentIndex = $[deck]('getCurrentSlideIndex');
+			var nbSlides = $[deck]('getSlides').length;
+            if (currentIndex === nbSlides -1 && !hasChanged && (e.which === keys.next || $.inArray(e.which, keys.next) > -1)) {
+                $[deck]('manageAnimations', e, currentIndex, currentIndex);
+            }
+			if (currentIndex === 0 && !hasChanged && (e.which === keys.previous || $.inArray(e.which, keys.previous) > -1)) {
+                $[deck]('manageAnimations', e, currentIndex, currentIndex);
+            }
+			hasChanged = false;
+        });
+		
+		// if there is no anchor, deck.change isn't trigger and the page is loaded
+		if(!window.location.hash){
+			pageLoaded = true;
+		}
+    })
+	.bind('deck.beforeChange', function(e, from, to) {
+		$[deck]('manageAnimations', e, from, to);
 	})
 	
 	.bind('deck.change', function(e, from, to) {

--- a/extensions/animator/deck.animator.js
+++ b/extensions/animator/deck.animator.js
@@ -24,6 +24,11 @@ Slides can include elements which then can be animated using the Animator.
 		}
 		return -1;
     });
+	
+	$[deck]('extend', 'getAnimator', function(slideNum) {
+		var $slide = $[deck]('getSlide', slideNum);
+		return eval($slide.data('dahu-animator'));
+	});
 	   
     /*
         jQuery.deck('Init')
@@ -49,32 +54,33 @@ Slides can include elements which then can be animated using the Animator.
     
 	.bind('deck.beforeChange', function(e, from, to) {
 		hasChanged = false;
-		var $slide = $[deck]('getSlide', from);
+		
 		console.log('from = ' + from)
 		console.log('to = ' + to)
 		/*
 		 * If the animations of the current slide are not complete,
 		 * we keep on doing them and we don't go to the next slide.
 		 */
-		var animator = eval($slide.data('dahu-animator'));
-		console.log("beforeChange : début");
+		var animator = $[deck]('getAnimator', from);
 		if ( animator !== undefined ) {
-			console.log("animator detected");
-			if( (from < to || (from === to && to === $[deck]('getSlides').length - 1)) && (! animator.isCompleted()) ) {
-				console.log("beforeChange : on ne passe pas !");
+			var toAnimator = $[deck]('getAnimator', to);
+			// on the case the animation hasn't yet been initialized
+			// for example, when the presentation hasn't been loaded from the first slide
+			if(from > to && !toAnimator.isCompleted()) {
+				toAnimator.startFromTheEnd();
+			}
+			if( (from === to-1 || (from === to && to === $[deck]('getSlides').length - 1)) && (! animator.isCompleted()) ) {
 				e.preventDefault();
 				if ( animator.getCursor() == 0 ) {
 					animator.restart();
 				} else {
 					animator.next();
 				} 
-			} else if ((from > to || (from === to && to === 0)) && animator.getCursor() !== 0) {
-				console.log("go back from cursor " + animator.getCursor());
+			} else if ((from === to+1 || (from === to && to === 0)) && animator.getCursor() !== 0) {
 				e.preventDefault();
 				animator.prev();
 			}
 		}
-		console.log("beforeChange : fin");
 	})
 	
 	.bind('deck.change', function(e, from, to) {

--- a/extensions/animator/deck.animator.js
+++ b/extensions/animator/deck.animator.js
@@ -49,15 +49,22 @@ Slides can include elements which then can be animated using the Animator.
 		 */
 		var animator = eval($slide.data('dahu-animator'));
 		console.log("beforeChange : début");
-		console.log(animator)
-		if ( animator !== undefined && (! animator.isCompleted()) ) {
-			console.log("beforeChange : on ne passe pas !");
-			e.preventDefault();
-			if ( animator.cursor == 0 ) {
-				animator.restart();
-			} else {
-				animator.next();
-			} 
+		console.log(animator);
+		console.log(animator.getCursor());
+		if ( animator !== undefined ) {
+			if( from < to && (! animator.isCompleted()) ) {
+				console.log("beforeChange : on ne passe pas !");
+				e.preventDefault();
+				if ( animator.getCursor() == 0 ) {
+					animator.restart();
+				} else {
+					animator.next();
+				} 
+			} else if (from > to && animator.getCursor() !== 0) {
+				console.log("go back from cursor " + animator.getCursor());
+				e.preventDefault();
+				animator.prev();
+			}
 		}
 		console.log("beforeChange : fin");
 	});

--- a/extensions/animator/deck.animator.js
+++ b/extensions/animator/deck.animator.js
@@ -51,11 +51,11 @@ Slides can include elements which then can be animated using the Animator.
 			animations = new Array();
 			for(animInd = 0; animInd < animationsJSON.length; ++animInd) {
 				if(animationsJSON[animInd].type === "move") {
-					animations.push(Animator.Move(animInd, animationsJSON[animInd-1], animationsJSON[animInd], animationsJSON[animInd+1]));
+					animations.push(Animator.Move(animInd, animationsJSON[animInd]));
 				} else if (animationsJSON[animInd].type === 'appear') {
-					animations.push(Animator.Appear(animInd, animationsJSON[animInd-1], animationsJSON[animInd], animationsJSON[animInd+1]));
+					animations.push(Animator.Appear(animInd, animationsJSON[animInd]));
 				} else if (animationsJSON[animInd].type === 'disappear') {
-					animations.push(Animator.Disappear(animInd, animationsJSON[animInd-1], animationsJSON[animInd], animationsJSON[animInd+1]));
+					animations.push(Animator.Disappear(animInd, animationsJSON[animInd]));
 				}
 			}
 			animationsJSON.forEach( function(a){
@@ -107,11 +107,11 @@ Slides can include elements which then can be animated using the Animator.
 				if ( !animator.hasStarted() ) {
 					animator.restart();
 				} else {
-					animator.next();
+					animator.next(true);
 				} 
 			} else if ((from === to+1 || (from === to && to === 0)) && animator.hasStarted()) {
 				e.preventDefault();
-				animator.prev();
+				animator.prev(true);
 			}
 		}
 	})

--- a/extensions/animator/deck.animator.js
+++ b/extensions/animator/deck.animator.js
@@ -1,0 +1,81 @@
+/*!
+Deck JS - deck.animator
+Copyright (c) 2011-2015 Remi BARRAQUAND, Rémy DELANAUX, Maxime PIA
+Dual licensed under the MIT license and GPL license.
+https://github.com/imakewebthings/deck.js/blob/master/MIT-license.txt
+https://github.com/imakewebthings/deck.js/blob/master/GPL-license.txt
+*/
+
+/*
+This module provides a support for animated SVG to the deck so as to create 
+animation like in most presentation solution e.g powerpoint, keynote, etc.
+Slides can include elements which then can be animated using the Animator.
+*/
+
+(function($, deck, undefined) {
+    var $d = $(document);
+       
+    /*
+        jQuery.deck('Init')
+        */
+    $d.bind('deck.init', function() {
+        var opts = $[deck]('getOptions');
+        var container = $[deck]('getContainer');
+
+		/* The animator name is stored in the slide using the data field in the HTML */
+		
+        /* Go through all slides */
+		/*
+        $.each($[deck]('getSlides'), function(i, $el) {
+            var $slide = $[deck]('getSlide',i);
+            
+            if( $slide.has("[class='deckjs-animated-element']").length>0 ) {
+                $slide.data('animator') = $slide.data('dahu-animator');
+            } else {
+				$slide.data('animator') = undefined;
+			}
+        });
+		*/
+		
+		
+    })
+	
+    /* Update current slide number with each change event */
+    .bind('deck.change', function(e, from, to) {
+        var opts = $[deck]('getOptions');
+        var $slideTo = $[deck]('getSlide', to);
+        var $container = $[deck]('getContainer');
+	
+        /* Restart the animator in the slide */
+		console.log("Parcours de l'animator");
+        if( eval($slideTo.data('dahu-animator')) !== undefined ) {
+			console.log("Reset de l'animator");
+            eval($slideTo.data('dahu-animator')).restart();
+        }
+        console.log("Passage à la suivante");
+    })
+    
+	.bind('deck.beforeChange', function(e, from, to) {
+		var $slide = $[deck]('getSlide', from);
+		
+		/*
+		 * If the animations of the current slide are not complete,
+		 * we keep on doing them and we don't go to the next slide.
+		 */
+		var animator = eval($slide.data('dahu-animator'));
+		console.log("beforeChange : début");
+		console.log(animator)
+		if ( animator !== undefined && (! animator.isCompleted()) ) {
+			console.log("beforeChange : on ne passe pas !");
+			e.preventDefault();
+			if ( animator.cursor == 0 ) {
+				animator.restart();
+			} else {
+				animator.next();
+			} 
+		}
+		console.log("beforeChange : fin");
+	});
+	
+		
+})(jQuery, 'deck');

--- a/extensions/animator/deck.animator.js
+++ b/extensions/animator/deck.animator.js
@@ -41,6 +41,7 @@ Slides can include elements which then can be animated using the Animator.
 		*/
 	$[deck]('extend', 'getAnimator', function(slideNum) {
 		var $slide = $[deck]('getSlide', slideNum);
+		if(!$slide) return undefined;
 		return $slide.data('slide-animator');
 	});
 	
@@ -136,9 +137,11 @@ Slides can include elements which then can be animated using the Animator.
 				}
 			} else {
 				if (currentIndex === nbSlides -1 && !slideChangeHappened && (e.which === keys.next || $.inArray(e.which, keys.next) > -1)) {
+					autoplayEnabled = false;
 					manageAnimations(undefined, currentIndex, currentIndex);
 				}
 				if (currentIndex === 0 && !slideChangeHappened && (e.which === keys.previous || $.inArray(e.which, keys.previous) > -1)) {
+					autoplayEnabled = false;
 					manageAnimations(undefined, currentIndex, currentIndex);
 				}
 				slideChangeHappened = false;

--- a/extensions/animator/deck.animator.js
+++ b/extensions/animator/deck.animator.js
@@ -47,27 +47,14 @@ Slides can include elements which then can be animated using the Animator.
 			if(!animatorJSON) continue;
 			var animationsJSON = animatorJSON.actions;
 			animations = new Array();
-			previousEltId = undefined;
-			nextEltId = undefined;
-			nextEltTrigger = undefined;
 			for(animInd = 0; animInd < animationsJSON.length; ++animInd) {
-				var a = animationsJSON[animInd];
-				var nextA = animationsJSON[animInd+1];
-				if(nextA !== undefined) {
-					nextEltId = nextA.target;
-					nextEltTrigger = nextA.trigger;
-				} else {
-					nextEltId = undefined;
-					nextEltTrigger = undefined;
+				if(animationsJSON[animInd].type === "move") {
+					animations.push(Animator.Move(animationsJSON[animInd-1], animationsJSON[animInd], animationsJSON[animInd+1]));
+				} else if (animationsJSON[animInd].type === 'appear') {
+					animations.push(Animator.Appear(animationsJSON[animInd-1], animationsJSON[animInd], animationsJSON[animInd+1]));
+				} else if (animationsJSON[animInd].type === 'disappear') {
+					animations.push(Animator.Disappear(animationsJSON[animInd-1], animationsJSON[animInd], animationsJSON[animInd+1]));
 				}
-				if(a.type === "move") {
-					animations.push(Animator.Move(a.target, parseInt(a.trX), parseInt(a.trY), parseInt(a.duration), previousEltId, nextEltId, nextEltTrigger, a.trigger));
-				} else if (a.type === 'appear') {
-					animations.push(Animator.Appear(a.target, parseInt(a.duration), previousEltId, nextEltId, nextEltTrigger, a.trigger));
-				} else if (a.type === 'disappear') {
-					animations.push(Animator.Disappear(a.target, parseInt(a.duration), previousEltId, nextEltId, nextEltTrigger, a.trigger));
-				}
-				previousEltId = a.target;
 			}
 			animationsJSON.forEach( function(a){
 
@@ -115,12 +102,12 @@ Slides can include elements which then can be animated using the Animator.
 		if ( animator !== undefined && pageLoaded) {
 			if( (from === to-1 || (from === to && to === $[deck]('getSlides').length - 1)) && (! animator.isCompleted()) ) {
 				e.preventDefault();
-				if ( animator.getCursor() == 0 ) {
+				if ( !animator.hasStarted() ) {
 					animator.restart();
 				} else {
 					animator.next();
 				} 
-			} else if ((from === to+1 || (from === to && to === 0)) && animator.getCursor() !== 0) {
+			} else if ((from === to+1 || (from === to && to === 0)) && animator.hasStarted()) {
 				e.preventDefault();
 				animator.prev();
 			}

--- a/extensions/animator/deck.animator.js
+++ b/extensions/animator/deck.animator.js
@@ -39,21 +39,6 @@ Slides can include elements which then can be animated using the Animator.
 		
 		
     })
-	
-    /* Update current slide number with each change event */
-    .bind('deck.change', function(e, from, to) {
-        var opts = $[deck]('getOptions');
-        var $slideTo = $[deck]('getSlide', to);
-        var $container = $[deck]('getContainer');
-	
-        /* Restart the animator in the slide */
-		console.log("Parcours de l'animator");
-        if( eval($slideTo.data('dahu-animator')) !== undefined ) {
-			console.log("Reset de l'animator");
-            eval($slideTo.data('dahu-animator')).restart();
-        }
-        console.log("Passage à la suivante");
-    })
     
 	.bind('deck.beforeChange', function(e, from, to) {
 		var $slide = $[deck]('getSlide', from);

--- a/extensions/animator/deck.animator.js
+++ b/extensions/animator/deck.animator.js
@@ -12,6 +12,8 @@ animation like in most presentation solution e.g powerpoint, keynote, etc.
 Slides can include elements which then can be animated using the Animator.
 */
 
+// TODO : refactor
+
 (function($, deck, undefined) {
     var $d = $(document);
 	// determines whether a actuel change in slide number has occured before the next action
@@ -49,11 +51,11 @@ Slides can include elements which then can be animated using the Animator.
 			animations = new Array();
 			for(animInd = 0; animInd < animationsJSON.length; ++animInd) {
 				if(animationsJSON[animInd].type === "move") {
-					animations.push(Animator.Move(animationsJSON[animInd-1], animationsJSON[animInd], animationsJSON[animInd+1]));
+					animations.push(Animator.Move(animInd, animationsJSON[animInd-1], animationsJSON[animInd], animationsJSON[animInd+1]));
 				} else if (animationsJSON[animInd].type === 'appear') {
-					animations.push(Animator.Appear(animationsJSON[animInd-1], animationsJSON[animInd], animationsJSON[animInd+1]));
+					animations.push(Animator.Appear(animInd, animationsJSON[animInd-1], animationsJSON[animInd], animationsJSON[animInd+1]));
 				} else if (animationsJSON[animInd].type === 'disappear') {
-					animations.push(Animator.Disappear(animationsJSON[animInd-1], animationsJSON[animInd], animationsJSON[animInd+1]));
+					animations.push(Animator.Disappear(animInd, animationsJSON[animInd-1], animationsJSON[animInd], animationsJSON[animInd+1]));
 				}
 			}
 			animationsJSON.forEach( function(a){

--- a/extensions/animator/deck.animator.js
+++ b/extensions/animator/deck.animator.js
@@ -7,12 +7,10 @@ https://github.com/imakewebthings/deck.js/blob/master/GPL-license.txt
 */
 
 /*
-This module provides a support for animated SVG to the deck so as to create 
+This module provides a support for animated elements to the deck so as to create 
 animation like in most presentation solution e.g powerpoint, keynote, etc.
 Slides can include elements which then can be animated using the Animator.
 */
-
-// TODO : refactor
 
 (function($, deck, undefined) {
     var $d = $(document);

--- a/extensions/animator/deck.animator.js
+++ b/extensions/animator/deck.animator.js
@@ -15,7 +15,7 @@ Slides can include elements which then can be animated using the Animator.
 (function($, deck, undefined) {
     var $d = $(document);
 	// determine whether a actual change in slide number has occured before the next action
-	hasChanged = false;
+	slideChangeHappened = false;
 	// determine whether the animators have finished initializing
 	pageLoaded = false;
 	
@@ -66,8 +66,8 @@ Slides can include elements which then can be animated using the Animator.
 	/*
 		Call animation functions when necessary.
 		*/
-	$[deck]('extend', 'manageAnimations', function(e, from, to) {
-		hasChanged = false;
+	function manageAnimations(e, from, to) {
+		slideChangeHappened = false;
 
 		/*
 		 * If the animations of the current slide are not complete,
@@ -89,7 +89,7 @@ Slides can include elements which then can be animated using the Animator.
 				animator.prev(true);
 			}
 		}
-	});
+	}
 	   
     /*
         jQuery.deck('Init')
@@ -104,13 +104,13 @@ Slides can include elements which then can be animated using the Animator.
         $d.unbind('keydown.deckanimator').bind('keydown.deckanimator', function(e) {
 			var currentIndex = $[deck]('getCurrentSlideIndex');
 			var nbSlides = $[deck]('getSlides').length;
-            if (currentIndex === nbSlides -1 && !hasChanged && (e.which === keys.next || $.inArray(e.which, keys.next) > -1)) {
-                $[deck]('manageAnimations', e, currentIndex, currentIndex);
+            if (currentIndex === nbSlides -1 && !slideChangeHappened && (e.which === keys.next || $.inArray(e.which, keys.next) > -1)) {
+                manageAnimations(e, currentIndex, currentIndex);
             }
-			if (currentIndex === 0 && !hasChanged && (e.which === keys.previous || $.inArray(e.which, keys.previous) > -1)) {
-                $[deck]('manageAnimations', e, currentIndex, currentIndex);
+			if (currentIndex === 0 && !slideChangeHappened && (e.which === keys.previous || $.inArray(e.which, keys.previous) > -1)) {
+                manageAnimations(e, currentIndex, currentIndex);
             }
-			hasChanged = false;
+			slideChangeHappened = false;
         });
 		
 		// if there is no anchor, deck.change won't be triggered and the page has finished loading
@@ -119,11 +119,11 @@ Slides can include elements which then can be animated using the Animator.
 		}
     })
 	.bind('deck.beforeChange', function(e, from, to) {
-		$[deck]('manageAnimations', e, from, to);
+		manageAnimations(e, from, to);
 	})
 	
 	.bind('deck.change', function(e, from, to) {
-		hasChanged = true;
+		slideChangeHappened = true;
 		// when the presentation hasn't been loaded from the first slide,
 		// the previous animations are set to their final states
 		if(!pageLoaded) {

--- a/extensions/asvg/deck.asvg.js
+++ b/extensions/asvg/deck.asvg.js
@@ -36,12 +36,12 @@ Slides can include svg documents which then can be animated using the Animator.
         $.each($[deck]('getSlides'), function(i, $el) {
             var $slide = $[deck]('getSlide',i);
             
-            if( $slide.has("object[type='deckjs/asvg']").length>0 ) {
+            if( $slide.has("object[class='deckjs-asvg-object']").length>0 ) {
                 $slide.data('animators', new Array());
             }
             
             /* Find all the object of type deckjs/asvg */
-            $slide.find("object[type='deckjs/asvg']").each(function(index) {
+            $slide.find("object[class='deckjs-asvg-object']").each(function(index) {
                 var id = $(this)
                 /* Load attributes and validate them */
                 var attributes = loadObjectParams(this);


### PR DESCRIPTION
The autoplay used to stop working when several consecutive slides had no animator / an empty animator.

What is more, an empty animator should be treated the same as an empty animator in most cases. Otherwise, it might perturb the transition between slides in the case where the presentation doesn't start at the first slide (by means of an anchor in the URL).